### PR TITLE
Publish XR lab performance results and wire up ResultsTable

### DIFF
--- a/src/components/ResultsTable.tsx
+++ b/src/components/ResultsTable.tsx
@@ -1,7 +1,7 @@
-import type { ResultRow } from '../types';
+import type { ExperimentResult } from '../data/performanceResults';
 
 type ResultsTableProps = {
-  rows: ResultRow[];
+  rows: ExperimentResult[];
 };
 
 export default function ResultsTable({ rows }: ResultsTableProps) {
@@ -11,8 +11,8 @@ export default function ResultsTable({ rows }: ResultsTableProps) {
         <thead className="bg-slate-50 text-xs uppercase tracking-wide text-slate-600">
           <tr>
             <th className="px-4 py-3">Experiment</th>
-            <th className="px-4 py-3">Baseline CPU/GPU (ms)</th>
-            <th className="px-4 py-3">Stress CPU/GPU (ms)</th>
+            <th className="px-4 py-3">Baseline CPU/GPU</th>
+            <th className="px-4 py-3">Stress CPU/GPU</th>
             <th className="px-4 py-3">Bottleneck</th>
             <th className="px-4 py-3">Root Cause</th>
             <th className="px-4 py-3">Mitigation</th>
@@ -20,8 +20,8 @@ export default function ResultsTable({ rows }: ResultsTableProps) {
         </thead>
         <tbody className="divide-y divide-slate-100 text-slate-700">
           {rows.map((row) => (
-            <tr key={row.experiment}>
-              <td className="px-4 py-3 font-medium text-slate-900">{row.experiment}</td>
+            <tr key={row.name}>
+              <td className="px-4 py-3 font-medium text-slate-900">{row.name}</td>
               <td className="px-4 py-3">{row.baseline}</td>
               <td className="px-4 py-3">{row.stress}</td>
               <td className="px-4 py-3">{row.bottleneck}</td>

--- a/src/data/performanceResults.ts
+++ b/src/data/performanceResults.ts
@@ -1,0 +1,32 @@
+export interface ExperimentResult {
+  name: string;
+  baseline: string;
+  stress: string;
+  bottleneck: string;
+  rootCause: string;
+  mitigation: string;
+  notes: string;
+}
+
+export const performanceResults: ExperimentResult[] = [
+  {
+    name: 'Baseline Scene',
+    baseline: '8.53 / 6.88 ms',
+    stress: 'N/A',
+    bottleneck: 'None (within frame budget)',
+    rootCause:
+      'Minimal scene complexity. No transparency, no post-processing, no overdraw. GPU has headroom (~1.6 ms).',
+    mitigation: 'Not required.',
+    notes: 'Stable near 120 Hz. GPU underutilized relative to frame budget.'
+  },
+  {
+    name: 'Overdraw Stress Toggle',
+    baseline: '8.53 / 6.88 ms',
+    stress: '12.63 / 12.03 ms',
+    bottleneck: 'GPU-bound',
+    rootCause: 'Fragment overdraw scaling in XR from stacked transparency and stereo fragment workload.',
+    mitigation: 'Reduce transparency / optimize fill-rate.',
+    notes:
+      'Moderate (40 layers): CPU 12.63 / GPU 12.03 ms. Extreme (200 layers): CPU 18.23 / GPU 17.79 ms.'
+  }
+];

--- a/src/sections/XRLabSection.tsx
+++ b/src/sections/XRLabSection.tsx
@@ -2,12 +2,8 @@ import EvidenceCard from '../components/EvidenceCard';
 import ExperimentAccordion from '../components/ExperimentAccordion';
 import ResultsTable from '../components/ResultsTable';
 import SectionHeading from '../components/SectionHeading';
-import { xrExperiments, xrLabConfig, xrResultRows } from '../data/xrLab';
-
-const publishedResults = [
-  { experiment: 'Baseline Scene', cpu: '—', gpu: '—', bottleneck: '—', notes: 'Not measured yet' },
-  { experiment: 'Overdraw Stress Toggle', cpu: '—', gpu: '—', bottleneck: '—', notes: 'Not measured yet' }
-];
+import { performanceResults } from '../data/performanceResults';
+import { xrExperiments, xrLabConfig } from '../data/xrLab';
 
 const evidenceItems = [
   {
@@ -46,7 +42,7 @@ export default function XRLabSection() {
             Target: {xrLabConfig.target}
           </span>
         </div>
-        <p className="mt-3 text-xs text-slate-600">Baseline and first experiments publish as validated measurements land.</p>
+        <p className="mt-3 text-xs text-slate-600">Baseline and overdraw stress milestones are now published with validated measurements.</p>
       </div>
 
       <div className="space-y-10">
@@ -57,37 +53,16 @@ export default function XRLabSection() {
 
         <div>
           <h3 className="mb-2 text-xl font-semibold text-slate-900">Published Results</h3>
-          <p className="mb-3 text-xs text-slate-500">Last updated: {lastUpdated}</p>
-          <div className="overflow-x-auto rounded-2xl border border-slate-200 bg-white shadow-sm">
-            <table className="min-w-full divide-y divide-slate-200 text-left text-sm">
-              <thead className="bg-slate-50 text-xs uppercase tracking-wide text-slate-600">
-                <tr>
-                  <th className="px-4 py-3">Experiment</th>
-                  <th className="px-4 py-3">CPU (ms)</th>
-                  <th className="px-4 py-3">GPU (ms)</th>
-                  <th className="px-4 py-3">Bottleneck</th>
-                  <th className="px-4 py-3">Notes</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-slate-100 text-slate-700">
-                {publishedResults.map((row) => (
-                  <tr key={row.experiment}>
-                    <td className="px-4 py-3 font-medium text-slate-900">{row.experiment}</td>
-                    <td className="px-4 py-3">{row.cpu}</td>
-                    <td className="px-4 py-3">{row.gpu}</td>
-                    <td className="px-4 py-3">{row.bottleneck}</td>
-                    <td className="px-4 py-3">{row.notes}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+          <p className="mb-4 text-xs text-slate-500">Last updated: {lastUpdated}</p>
+          <ResultsTable rows={performanceResults} />
+          <div className="mt-4 space-y-2 rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+            <p className="font-semibold text-slate-900">Notes</p>
+            {performanceResults.map((result) => (
+              <p key={`${result.name}-notes`}>
+                <span className="font-medium text-slate-900">{result.name}:</span> {result.notes}
+              </p>
+            ))}
           </div>
-        </div>
-
-        <div>
-          <h3 className="mb-2 text-xl font-semibold text-slate-900">Results Table</h3>
-          <p className="mb-4 text-sm text-slate-600">This table is populated as experiments are profiled and validated.</p>
-          <ResultsTable rows={xrResultRows} />
         </div>
 
         <div>


### PR DESCRIPTION
### Motivation
- Publish final validated measurements for the XR Performance Stress Lab (Baseline Scene and Overdraw Stress Toggle) so the site shows concrete profiler-backed numbers. 
- Make the published results data-driven so future updates only require editing a single source file rather than scattering strings across components. 
- Surface additional validation notes (moderate and extreme overdraw cases) so readers can see both the primary stress value and extreme-case numbers.

### Description
- Add a new data module `src/data/performanceResults.ts` that defines `ExperimentResult` and exports `performanceResults` with finalized values and notes for the two experiments. 
- Update `src/components/ResultsTable.tsx` to accept `ExperimentResult[]` and render rows from `name/baseline/stress/bottleneck/rootCause/mitigation` instead of previous row types. 
- Refactor `src/sections/XRLabSection.tsx` to import `performanceResults`, remove the old `publishedResults` table, render the updated `ResultsTable` with `performanceResults`, and add a Notes block under the table that lists each experiment's notes (including the extreme-case numbers). 
- No skills from the local `AGENTS.md` skill list were used for this change because the edits were straightforward code and content updates. 
- A visual verification screenshot of the updated XR results section was captured from the local dev server during validation.

### Testing
- Ran `npm run lint` and it completed successfully. 
- Ran `npm run build` (Vite production build) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d13eaf4e4832481d0a045f46ebcaa)