### PR TITLE
Update placeholder repository links to XRPerformanceLab

### DIFF
--- a/src/caseStudies/pages/ProfilingToolkitCaseStudyPage.tsx
+++ b/src/caseStudies/pages/ProfilingToolkitCaseStudyPage.tsx
@@ -63,7 +63,7 @@ export default function ProfilingToolkitCaseStudyPage() {
         <ul className="list-disc space-y-2 pl-5 text-slate-700">
           <li>
             <a
-              href="https://github.com/placeholder/unity-profiling-overlay"
+              href="https://github.com/JamesDeRaja/XRPerformanceLab"
               className="hover:text-cyan-700 hover:underline"
             >
               Repository

--- a/src/caseStudies/pages/PublishedMobileProjectsCaseStudyPage.tsx
+++ b/src/caseStudies/pages/PublishedMobileProjectsCaseStudyPage.tsx
@@ -64,7 +64,7 @@ export default function PublishedMobileProjectsCaseStudyPage() {
         <h2 className="text-xl font-semibold text-slate-900">Links</h2>
         <ul className="list-disc space-y-2 pl-5 text-slate-700">
           <li>
-            <a href="https://github.com/placeholder/mobile-projects" className="hover:text-cyan-700 hover:underline">
+            <a href="https://github.com/JamesDeRaja/XRPerformanceLab" className="hover:text-cyan-700 hover:underline">
               Repository
             </a>
           </li>

--- a/src/caseStudies/pages/SoftMaskProCaseStudyPage.tsx
+++ b/src/caseStudies/pages/SoftMaskProCaseStudyPage.tsx
@@ -64,7 +64,7 @@ export default function SoftMaskProCaseStudyPage() {
         <h2 className="text-xl font-semibold text-slate-900">Links</h2>
         <ul className="list-disc space-y-2 pl-5 text-slate-700">
           <li>
-            <a href="https://github.com/placeholder/softmaskpro" className="hover:text-cyan-700 hover:underline">
+            <a href="https://github.com/JamesDeRaja/XRPerformanceLab" className="hover:text-cyan-700 hover:underline">
               Repository
             </a>
           </li>

--- a/src/caseStudies/pages/XRStressLabCaseStudyPage.tsx
+++ b/src/caseStudies/pages/XRStressLabCaseStudyPage.tsx
@@ -173,7 +173,7 @@ export default function XRStressLabCaseStudyPage() {
           <h2 className="text-xl font-semibold text-slate-900">Links</h2>
           <ul className="list-disc space-y-2 pl-5 text-slate-700">
             <li>
-              <a href="https://github.com/placeholder/xr-performance-lab" className="hover:text-cyan-700 hover:underline">
+              <a href="https://github.com/JamesDeRaja/XRPerformanceLab" className="hover:text-cyan-700 hover:underline">
                 Repository
               </a>
             </li>

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -16,7 +16,7 @@ export const workProjects: WorkProject[] = [
       'Classified CPU vs GPU submission bottlenecks via controlled toggles.'
     ],
     caseStudyUrl: '/case-studies/xr-stress-lab',
-    repoUrl: 'https://github.com/placeholder/xr-performance-lab',
+    repoUrl: 'https://github.com/JamesDeRaja/XRPerformanceLab',
     featured: true
   },
   {
@@ -34,7 +34,7 @@ export const workProjects: WorkProject[] = [
       'Documented ZWrite / Blend tradeoffs for predictable GPU cost.'
     ],
     caseStudyUrl: '/case-studies/softmaskpro',
-    repoUrl: 'https://github.com/placeholder/softmaskpro'
+    repoUrl: 'https://github.com/JamesDeRaja/XRPerformanceLab'
   },
   {
     id: 'perf-overlay',
@@ -51,7 +51,7 @@ export const workProjects: WorkProject[] = [
       'Reduced profiling turnaround through standardized capture snapshots.'
     ],
     caseStudyUrl: '/case-studies/profiling-toolkit',
-    repoUrl: 'https://github.com/placeholder/unity-profiling-overlay'
+    repoUrl: 'https://github.com/JamesDeRaja/XRPerformanceLab'
   },
   {
     id: 'mobile-projects',
@@ -68,6 +68,6 @@ export const workProjects: WorkProject[] = [
       'Applied profiling-driven mitigation pre- and post-launch.'
     ],
     caseStudyUrl: '/case-studies/published-mobile-projects',
-    repoUrl: 'https://github.com/placeholder/mobile-projects'
+    repoUrl: 'https://github.com/JamesDeRaja/XRPerformanceLab'
   }
 ];


### PR DESCRIPTION
### Motivation

- Consolidate and correct repository references across case study pages and project metadata so all links point to the actual XRPerformanceLab repository (`https://github.com/JamesDeRaja/XRPerformanceLab`).

### Description

- Replaced placeholder repo links with `https://github.com/JamesDeRaja/XRPerformanceLab` in `src/data/projects.ts` for the `xr-stress-lab`, `softmaskpro`, `perf-overlay`, and `mobile-projects` entries.
- Updated anchor `href` values in `ProfilingToolkitCaseStudyPage.tsx`, `PublishedMobileProjectsCaseStudyPage.tsx`, `SoftMaskProCaseStudyPage.tsx`, and `XRStressLabCaseStudyPage.tsx` to point to the same repository.

### Testing

- Ran a TypeScript type check with `tsc --noEmit` which completed successfully.
- Performed a dev build with `yarn build` which succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0fef559388324ac112de848a4e5cf)