### PR TITLE
Fix malformed SmartLink JSX in PublishedMobileProjectsCaseStudyPage

### DIFF
--- a/src/caseStudies/pages/PublishedMobileProjectsCaseStudyPage.tsx
+++ b/src/caseStudies/pages/PublishedMobileProjectsCaseStudyPage.tsx
@@ -117,13 +117,11 @@ export default function PublishedMobileProjectsCaseStudyPage() {
         <ul className="list-disc space-y-2 pl-5 text-slate-700">
           <li>
             <SmartLink
-            <a
               href="https://apps.apple.com/us/app/sneaky-warriour-3d/id1626719884"
               className="hover:text-cyan-700 hover:underline"
             >
               App Store
             </SmartLink>
-            </a>
           </li>
         </ul>
       </section>


### PR DESCRIPTION
### Motivation
- Fix a Vite/esbuild parse error caused by malformed JSX in the Links section of `PublishedMobileProjectsCaseStudyPage`, where an accidental nested `<a>` wrapper was placed inside a `SmartLink` component.

### Description
- Remove the stray nested `<a>` and closing tag and pass `href` and `className` directly to `SmartLink` in `src/caseStudies/pages/PublishedMobileProjectsCaseStudyPage.tsx` so the JSX is valid and consistent with other pages.

### Testing
- Ran `npm run build` and the Vite production build completed successfully (no parser/build errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5325c1ba88324a1118379c8d8e45d)