### PR TITLE
Use SmartLink for external links and update SoftMaskPro repo URL

### DIFF
--- a/src/caseStudies/pages/SoftMaskProCaseStudyPage.tsx
+++ b/src/caseStudies/pages/SoftMaskProCaseStudyPage.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import SmartLink from '../../components/SmartLink';
 
 export default function SoftMaskProCaseStudyPage() {
   return (
@@ -105,6 +106,18 @@ export default function SoftMaskProCaseStudyPage() {
           <li>
             Constrain redraw triggers: avoid unnecessary mask geometry animation, avoid per-frame SetVerticesDirty, and
             gate QueuePlayerLoopUpdate to resolution/view changes.
+          </li>
+        </ul>
+      </section>
+
+
+      <section className="mt-8 space-y-3">
+        <h2 className="text-xl font-semibold text-slate-900">Links</h2>
+        <ul className="list-disc space-y-2 pl-5 text-slate-700">
+          <li>
+            <SmartLink href="https://github.com/JamesDeRaja/SoftMaskPro-Performance-Study" className="hover:text-cyan-700 hover:underline">
+              Repository
+            </SmartLink>
           </li>
         </ul>
       </section>

--- a/src/components/WorkCard.tsx
+++ b/src/components/WorkCard.tsx
@@ -34,9 +34,6 @@ export default function WorkCard({ project }: WorkCardProps) {
         <SmartLink href={project.repoUrl} className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-800 hover:border-cyan-600 hover:text-cyan-700">
           {project.id === 'mobile-projects' ? 'App Store' : 'Repo'}
         </SmartLink>
-        <a href={project.repoUrl} className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-800 hover:border-cyan-600 hover:text-cyan-700">
-          {project.id === 'mobile-projects' ? 'App Store' : 'Repo'}
-        </a>
       </div>
     </article>
   );

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -32,7 +32,7 @@ export const workProjects: WorkProject[] = [
       'Documented ZWrite / Blend tradeoffs for predictable GPU cost.'
     ],
     caseStudyUrl: '/case-studies/softmaskpro',
-    repoUrl: 'https://github.com/JamesDeRaja/XRPerformanceLab'
+    repoUrl: 'https://github.com/JamesDeRaja/SoftMaskPro-Performance-Study'
   },
   {
     id: 'perf-overlay',


### PR DESCRIPTION
### Motivation
- Consolidate external link rendering to the `SmartLink` component for consistent styling and behavior across case study and work card pages.
- Correct the SoftMaskPro project metadata to point to the actual performance study repository URL.

### Description
- Import `SmartLink` in `src/caseStudies/pages/SoftMaskProCaseStudyPage.tsx` and add a new "Links" section that links to the repository using `SmartLink`.
- Replace the plain anchor in `src/components/WorkCard.tsx` with `SmartLink` and remove the duplicate anchor element.
- Update the `repoUrl` for the `softmaskpro` entry in `src/data/projects.ts` to `https://github.com/JamesDeRaja/SoftMaskPro-Performance-Study`.

### Testing
- No automated tests were run as part of this change; please run the project build and CI test suite (for example `yarn build` and your repository's test workflow) to validate integration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a590a1750c8324b3443cf785daefcf)