### PR TITLE
Improve SEO metadata across all routes and expand sitemap

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,14 @@
     <title>James De Raja — Real-Time Performance Engineer (Unity/XR)</title>
     <meta
       name="description"
-      content="Senior real-time performance engineer focused on Unity rendering, frame pacing discipline, and XR performance research with profiler-backed measurements."
+      content="Senior real-time performance engineer specialising in Unity rendering, frame pacing discipline and XR performance research with profiler-backed measurements."
+    />
+    <link rel="canonical" href="https://james.alphaden.club/" />
+    <meta name="robots" content="index,follow" />
+    <meta name="author" content="James De Raja" />
+    <meta
+      name="keywords"
+      content="James De Raja, real-time performance engineer, Unity performance, XR optimisation, frame pacing, rendering cost isolation, GPU/CPU bottleneck"
     />
     <meta property="og:title" content="James De Raja — Real-Time Performance Engineer (Unity/XR)" />
     <meta
@@ -15,8 +22,16 @@
       content="Unity rendering, frame pacing, and XR performance research with profiler-backed measurements."
     />
     <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://james.alphaden.club/" />
     <meta property="og:image" content="/og-image.png" />
-    <meta property="og:url" content="https://example.vercel.app" />
+    <meta property="og:site_name" content="James De Raja Portfolio" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="James De Raja — Real-Time Performance Engineer (Unity/XR)" />
+    <meta
+      name="twitter:description"
+      content="Unity rendering, frame pacing, and XR performance research with profiler-backed measurements."
+    />
+    <meta name="twitter:image" content="/og-image.png" />
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "nodemailer": "^7.0.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-helmet-async": "^3.0.0",
         "react-router-dom": "^6.30.3"
       },
       "devDependencies": {
@@ -2923,6 +2924,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -3724,6 +3734,26 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-helmet-async": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-3.0.0.tgz",
+      "integrity": "sha512-nA3IEZfXiclgrz4KLxAhqJqIfFDuvzQwlKwpdmzZIuC1KNSghDEIXmyU0TKtbM+NafnkICcwx8CECFrZ/sL/1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "react-fast-compare": "^3.2.2",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3933,6 +3963,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "nodemailer": "^7.0.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-helmet-async": "^3.0.0",
     "react-router-dom": "^6.30.3"
   },
   "devDependencies": {

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,12 +1,73 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset 
-  xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://james.alphaden.club/</loc>
-    <lastmod>2025-07-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
-  
+  <url>
+    <loc>https://james.alphaden.club/case-studies/xr-stress-lab</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://james.alphaden.club/case-studies/softmaskpro</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://james.alphaden.club/case-studies/profiling-toolkit</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://james.alphaden.club/case-studies/sneaky-warrior-3d</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://james.alphaden.club/case-studies/published-mobile-projects</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://james.alphaden.club/lab/overdraw</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://james.alphaden.club/lab/msaa</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://james.alphaden.club/lab/msaa-overdraw</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://james.alphaden.club/lab/instancing</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://james.alphaden.club/lab/frame-pacing</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://james.alphaden.club/lab/frame-pacing-vs-fps</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://james.alphaden.club/lab/xr-frame-timing</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://james.alphaden.club/lab/overdraw-stereo</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
 </urlset>

--- a/src/caseStudies/pages/ProfilingToolkitCaseStudyPage.tsx
+++ b/src/caseStudies/pages/ProfilingToolkitCaseStudyPage.tsx
@@ -1,9 +1,27 @@
 import { Link } from 'react-router-dom';
 import SmartLink from '../../components/SmartLink';
+import { Seo } from '../../components/Seo';
 
 export default function ProfilingToolkitCaseStudyPage() {
   return (
     <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
+      <Seo
+        title="Profiling Toolkit Case Study — James De Raja"
+        description="Case study on a Unity runtime profiling overlay that shortens bottleneck triage from symptom capture to mitigation-ready evidence."
+        url="https://james.alphaden.club/case-studies/profiling-toolkit"
+        keywords="Unity profiler toolkit, runtime overlay, bottleneck triage, performance telemetry"
+        type="article"
+        structuredData={{
+          '@context': 'https://schema.org',
+          '@type': 'Article',
+          headline: 'Profiling Toolkit Case Study',
+          description:
+            'Case study on a Unity runtime profiling overlay that shortens bottleneck triage from symptom capture to mitigation-ready evidence.',
+          author: { '@type': 'Person', name: 'James De Raja' },
+          datePublished: '2025-01-01',
+          image: '/og-image.png',
+        }}
+      />
       <div style={{ marginBottom: '16px' }}>
         <Link to="/">← Back to Home</Link>
       </div>

--- a/src/caseStudies/pages/PublishedMobileProjectsCaseStudyPage.tsx
+++ b/src/caseStudies/pages/PublishedMobileProjectsCaseStudyPage.tsx
@@ -1,9 +1,27 @@
 import { Link } from 'react-router-dom';
 import SmartLink from '../../components/SmartLink';
+import { Seo } from '../../components/Seo';
 
 export default function PublishedMobileProjectsCaseStudyPage() {
   return (
     <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
+      <Seo
+        title="Sneaky Warrior 3D Case Study — James De Raja"
+        description="Mobile performance case study covering frame budget stabilization for Sneaky Warrior 3D under heavy AI, ragdoll, and projectile load."
+        url="https://james.alphaden.club/case-studies/published-mobile-projects"
+        keywords="mobile performance, Unity optimization, frame budget, Sneaky Warrior 3D, frame pacing"
+        type="article"
+        structuredData={{
+          '@context': 'https://schema.org',
+          '@type': 'Article',
+          headline: 'Sneaky Warrior 3D Frame Budget Stabilization',
+          description:
+            'Mobile performance case study covering frame budget stabilization for Sneaky Warrior 3D under heavy AI, ragdoll, and projectile load.',
+          author: { '@type': 'Person', name: 'James De Raja' },
+          datePublished: '2025-01-01',
+          image: '/og-image.png',
+        }}
+      />
       <div style={{ marginBottom: '16px' }}>
         <Link to="/">← Back to Home</Link>
       </div>

--- a/src/caseStudies/pages/SoftMaskProCaseStudyPage.tsx
+++ b/src/caseStudies/pages/SoftMaskProCaseStudyPage.tsx
@@ -1,9 +1,27 @@
 import { Link } from 'react-router-dom';
 import SmartLink from '../../components/SmartLink';
+import { Seo } from '../../components/Seo';
 
 export default function SoftMaskProCaseStudyPage() {
   return (
     <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
+      <Seo
+        title="SoftMaskPro Optimization Case Study — James De Raja"
+        description="SoftMaskPro profiling and patching case study focused on UI mask draw calls, render pass overhead, and frame-time stabilization in Unity."
+        url="https://james.alphaden.club/case-studies/softmaskpro"
+        keywords="SoftMaskPro, Unity UI optimization, draw calls, frame timing, profiling"
+        type="article"
+        structuredData={{
+          '@context': 'https://schema.org',
+          '@type': 'Article',
+          headline: 'SoftMaskPro Optimization Case Study',
+          description:
+            'SoftMaskPro profiling and patching case study focused on UI mask draw calls, render pass overhead, and frame-time stabilization in Unity.',
+          author: { '@type': 'Person', name: 'James De Raja' },
+          datePublished: '2025-01-01',
+          image: '/og-image.png',
+        }}
+      />
       <div style={{ marginBottom: '16px' }}>
         <Link to="/">← Back to Home</Link>
       </div>

--- a/src/caseStudies/pages/XRStressLabCaseStudyPage.tsx
+++ b/src/caseStudies/pages/XRStressLabCaseStudyPage.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import SmartLink from '../../components/SmartLink';
 import MiniBars from '../../components/charts/MiniBars';
 import { getResultDelta, xrStressLabResults } from '../../data/xrStressLabResults';
+import { Seo } from '../../components/Seo';
 
 function formatDelta(value: number | null) {
   if (value === null) {
@@ -14,6 +15,23 @@ function formatDelta(value: number | null) {
 export default function XRStressLabCaseStudyPage() {
   return (
     <div className="min-h-screen bg-site-pattern">
+      <Seo
+        title="XR Stress Lab Case Study — James De Raja"
+        description="Controlled XR stress tests isolating overdraw, MSAA bandwidth, submission overhead, and frame pacing variance with profiler-backed evidence."
+        url="https://james.alphaden.club/case-studies/xr-stress-lab"
+        keywords="XR stress lab, overdraw, MSAA, instancing, frame pacing, Unity profiling"
+        type="article"
+        structuredData={{
+          '@context': 'https://schema.org',
+          '@type': 'Article',
+          headline: 'XR Stress Lab Case Study',
+          description:
+            'Controlled XR stress tests isolating overdraw, MSAA bandwidth, submission overhead, and frame pacing variance with profiler-backed evidence.',
+          author: { '@type': 'Person', name: 'James De Raja' },
+          datePublished: '2025-01-01',
+          image: '/og-image.png',
+        }}
+      />
       <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
         <div style={{ marginBottom: '16px' }}>
           <Link to="/">← Back to Home</Link>

--- a/src/components/EvidenceCard.tsx
+++ b/src/components/EvidenceCard.tsx
@@ -22,7 +22,7 @@ export default function EvidenceCard({ title, description, imagePath, caption }:
         ) : (
           <img
             src={imagePath}
-            alt={title}
+            alt={`${title} evidence screenshot`}
             loading="lazy"
             onError={() => setImageMissing(true)}
             className="h-full w-full object-cover"

--- a/src/components/IconContainer.tsx
+++ b/src/components/IconContainer.tsx
@@ -6,7 +6,7 @@ const IconContainer = () => {
     <div className="w-12 h-12 bg-white/30 rounded-full flex items-center justify-center shadow-lg backdrop-blur-sm">
       <img 
         src="/images/Icon_3.png" 
-        alt="Custom Icon" 
+        alt="Performance metrics icon" 
         className="w-12 h-12"
       />
     </div>

--- a/src/components/ResultsTable.tsx
+++ b/src/components/ResultsTable.tsx
@@ -18,7 +18,7 @@ function formatBottleneck(bottleneck: string) {
 export default function ResultsTable({ rows }: ResultsTableProps) {
   return (
     <div className="overflow-x-auto rounded-2xl border border-slate-200 bg-white shadow-sm">
-      <table className="min-w-full divide-y divide-slate-200 text-left text-sm">
+      <table className="min-w-full divide-y divide-slate-200 text-left text-sm" aria-label="XR performance experiment results">
         <thead className="bg-slate-50 text-xs uppercase tracking-wide text-slate-600">
           <tr>
             <th className="px-4 py-3">Experiment</th>

--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -1,0 +1,60 @@
+import { Helmet } from 'react-helmet-async';
+
+type JsonLd = Record<string, unknown> | Array<Record<string, unknown>>;
+
+export type SEOProps = {
+  title: string;
+  description: string;
+  url: string;
+  image?: string;
+  keywords?: string;
+  type?: string;
+  structuredData?: JsonLd;
+};
+
+export function Seo({
+  title,
+  description,
+  url,
+  image = '/og-image.png',
+  keywords,
+  type = 'website',
+  structuredData,
+}: SEOProps) {
+  const personSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: 'James De Raja',
+    jobTitle: 'Senior Real-Time Performance Engineer',
+    url,
+    sameAs: ['https://github.com/JamesDeRaja'],
+  };
+
+  const schemas = structuredData
+    ? [personSchema, ...(Array.isArray(structuredData) ? structuredData : [structuredData])]
+    : [personSchema];
+
+  return (
+    <Helmet>
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      {keywords && <meta name="keywords" content={keywords} />}
+      <link rel="canonical" href={url} />
+      <meta name="robots" content="index,follow" />
+      <meta name="author" content="James De Raja" />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:type" content={type} />
+      <meta property="og:url" content={url} />
+      <meta property="og:image" content={image} />
+      <meta property="og:site_name" content="James De Raja Portfolio" />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+      <meta name="twitter:image" content={image} />
+      {schemas.map((schema, index) => (
+        <script key={index} type="application/ld+json">{JSON.stringify(schema)}</script>
+      ))}
+    </Helmet>
+  );
+}

--- a/src/components/charts/MiniBars.tsx
+++ b/src/components/charts/MiniBars.tsx
@@ -27,7 +27,13 @@ export default function MiniBars({
   const delta = stressMs === undefined ? null : stressMs - baselineMs;
 
   return (
-    <article className="rounded-xl border border-slate-200 bg-white p-3">
+    <article
+      className="rounded-xl border border-slate-200 bg-white p-3"
+      role="img"
+      aria-label={`${title}: ${labelLeft} ${baselineMs.toFixed(2)} milliseconds${
+        stressMs === undefined ? '' : `, ${labelRight} ${stressMs.toFixed(2)} milliseconds`
+      }`}
+    >
       <p className="text-sm font-medium text-slate-900">{title}</p>
       <div className="mt-3 space-y-2">
         <div className="grid grid-cols-[68px_1fr_auto] items-center gap-2">
@@ -42,7 +48,10 @@ export default function MiniBars({
           <div className="grid grid-cols-[68px_1fr_auto] items-center gap-2">
             <span className="text-xs text-slate-600">{labelRight}</span>
             <div className="h-2.5 rounded-full bg-slate-100">
-              <div className={`h-2.5 rounded-full ${variant === 'gpu' ? 'bg-cyan-600' : 'bg-slate-600'}`} style={{ width: `${stressWidth}%` }} />
+              <div
+                className={`h-2.5 rounded-full ${variant === 'gpu' ? 'bg-cyan-600' : 'bg-slate-600'}`}
+                style={{ width: `${stressWidth}%` }}
+              />
             </div>
             <span className="text-xs text-slate-700">{stressMs.toFixed(2)} ms</span>
           </div>

--- a/src/lab/pages/FramePacingLabPage.tsx
+++ b/src/lab/pages/FramePacingLabPage.tsx
@@ -1,8 +1,25 @@
 import { Link } from 'react-router-dom';
+import { Seo } from '../../components/Seo';
 
 export default function FramePacingLabPage() {
   return (
     <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
+      <Seo
+        title="Frame Pacing Lab — James De Raja"
+        description="Frame pacing lab focused on variance, spikes, and cadence stability beyond average FPS using profiler-backed measurements."
+        url="https://james.alphaden.club/lab/frame-pacing"
+        keywords="frame pacing, frame variance, Unity profiler, stutter analysis"
+        type="article"
+        structuredData={{
+          '@context': 'https://schema.org',
+          '@type': 'CreativeWork',
+          headline: 'Frame Pacing Lab',
+          description: 'Frame pacing lab focused on variance, spikes, and cadence stability beyond average FPS using profiler-backed measurements.',
+          author: { '@type': 'Person', name: 'James De Raja' },
+          datePublished: '2025-01-01',
+          image: '/og-image.png',
+        }}
+      />
       <div style={{ marginBottom: '16px' }}>
         <Link to="/case-studies/xr-stress-lab">← Back to XR Stress Lab Case Study</Link>
       </div>

--- a/src/lab/pages/FramePacingVsFPSLabPage.tsx
+++ b/src/lab/pages/FramePacingVsFPSLabPage.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import { Seo } from '../../components/Seo';
 
 export default function FramePacingVsFPSLabPage() {
   const hz = 72;
@@ -7,6 +8,22 @@ export default function FramePacingVsFPSLabPage() {
 
   return (
     <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
+      <Seo
+        title="Frame Pacing vs FPS Lab — James De Raja"
+        description="Lab article showing why stable frame pacing can outperform higher but inconsistent FPS in XR and real-time rendering workloads."
+        url="https://james.alphaden.club/lab/frame-pacing-vs-fps"
+        keywords="frame pacing vs FPS, XR performance, frame stability, Unity"
+        type="article"
+        structuredData={{
+          '@context': 'https://schema.org',
+          '@type': 'CreativeWork',
+          headline: 'Frame Pacing vs FPS Lab',
+          description: 'Lab article showing why stable frame pacing can outperform higher but inconsistent FPS in XR and real-time rendering workloads.',
+          author: { '@type': 'Person', name: 'James De Raja' },
+          datePublished: '2025-01-01',
+          image: '/og-image.png',
+        }}
+      />
       <div style={{ marginBottom: '16px' }}>
         <Link to="/?section=writing">← Back to Writing</Link>
       </div>

--- a/src/lab/pages/InstancingLabPage.tsx
+++ b/src/lab/pages/InstancingLabPage.tsx
@@ -1,9 +1,26 @@
 import { Link } from 'react-router-dom';
 import MetricsSummary from '../components/MetricsSummary';
+import { Seo } from '../../components/Seo';
 
 export default function InstancingLabPage() {
   return (
     <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
+      <Seo
+        title="Instancing Lab — James De Raja"
+        description="Instancing lab comparing draw submission overhead and CPU render-thread savings between instanced and non-instanced scenes."
+        url="https://james.alphaden.club/lab/instancing"
+        keywords="instancing lab, draw calls, render thread, Unity optimization"
+        type="article"
+        structuredData={{
+          '@context': 'https://schema.org',
+          '@type': 'CreativeWork',
+          headline: 'Instancing Lab',
+          description: 'Instancing lab comparing draw submission overhead and CPU render-thread savings between instanced and non-instanced scenes.',
+          author: { '@type': 'Person', name: 'James De Raja' },
+          datePublished: '2025-01-01',
+          image: '/og-image.png',
+        }}
+      />
       <div style={{ marginBottom: '16px' }}>
         <Link to="/case-studies/xr-stress-lab">← Back to XR Stress Lab Case Study</Link>
       </div>

--- a/src/lab/pages/MSAALabPage.tsx
+++ b/src/lab/pages/MSAALabPage.tsx
@@ -1,9 +1,26 @@
 import { Link } from 'react-router-dom';
 import MetricsSummary from '../components/MetricsSummary';
+import { Seo } from '../../components/Seo';
 
 export default function MSAALabPage() {
   return (
     <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
+      <Seo
+        title="MSAA Scaling Lab — James De Raja"
+        description="MSAA scaling lab measuring GPU bandwidth amplification and frame-time impact across anti-aliasing levels in controlled Unity scenes."
+        url="https://james.alphaden.club/lab/msaa"
+        keywords="MSAA scaling, Unity performance, GPU bandwidth, anti-aliasing"
+        type="article"
+        structuredData={{
+          '@context': 'https://schema.org',
+          '@type': 'CreativeWork',
+          headline: 'MSAA Scaling Lab',
+          description: 'MSAA scaling lab measuring GPU bandwidth amplification and frame-time impact across anti-aliasing levels in controlled Unity scenes.',
+          author: { '@type': 'Person', name: 'James De Raja' },
+          datePublished: '2025-01-01',
+          image: '/og-image.png',
+        }}
+      />
       <div style={{ marginBottom: '16px' }}>
         <Link to="/case-studies/xr-stress-lab">← Back to XR Stress Lab Case Study</Link>
       </div>

--- a/src/lab/pages/MSAAOverdrawLabPage.tsx
+++ b/src/lab/pages/MSAAOverdrawLabPage.tsx
@@ -1,5 +1,27 @@
 import { Navigate } from 'react-router-dom';
+import { Seo } from '../../components/Seo';
 
 export default function MSAAOverdrawLabPage() {
-  return <Navigate to="/lab/msaa#msaa-overdraw" replace />;
+  return (
+    <>
+      <Seo
+        title="MSAA + Overdraw Lab — James De Raja"
+        description="Landing route for the MSAA-overdraw interaction study covering compounded bandwidth and fragment pressure in Unity XR rendering."
+        url="https://james.alphaden.club/lab/msaa-overdraw"
+        keywords="MSAA overdraw, Unity XR, bandwidth amplification, fragment bottleneck"
+        type="article"
+        structuredData={{
+          '@context': 'https://schema.org',
+          '@type': 'CreativeWork',
+          headline: 'MSAA + Overdraw Lab',
+          description:
+            'Landing route for the MSAA-overdraw interaction study covering compounded bandwidth and fragment pressure in Unity XR rendering.',
+          author: { '@type': 'Person', name: 'James De Raja' },
+          datePublished: '2025-01-01',
+          image: '/og-image.png',
+        }}
+      />
+      <Navigate to="/lab/msaa#msaa-overdraw" replace />
+    </>
+  );
 }

--- a/src/lab/pages/OverdrawLabPage.tsx
+++ b/src/lab/pages/OverdrawLabPage.tsx
@@ -1,9 +1,26 @@
 import { Link } from 'react-router-dom';
 import MetricsSummary from '../components/MetricsSummary';
+import { Seo } from '../../components/Seo';
 
 export default function OverdrawLabPage() {
   return (
     <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
+      <Seo
+        title="Overdraw Lab — James De Raja"
+        description="Controlled overdraw stress test quantifying fragment pressure, transparent pass escalation, and GPU bottleneck behavior in Unity XR."
+        url="https://james.alphaden.club/lab/overdraw"
+        keywords="overdraw lab, GPU fragment pressure, Unity XR, transparent pass"
+        type="article"
+        structuredData={{
+          '@context': 'https://schema.org',
+          '@type': 'CreativeWork',
+          headline: 'Overdraw Lab',
+          description: 'Controlled overdraw stress test quantifying fragment pressure, transparent pass escalation, and GPU bottleneck behavior in Unity XR.',
+          author: { '@type': 'Person', name: 'James De Raja' },
+          datePublished: '2025-01-01',
+          image: '/og-image.png',
+        }}
+      />
       <div style={{ marginBottom: '16px' }}>
         <Link to="/case-studies/xr-stress-lab">← Back to XR Stress Lab Case Study</Link>
       </div>

--- a/src/lab/pages/OverdrawStereoLabPage.tsx
+++ b/src/lab/pages/OverdrawStereoLabPage.tsx
@@ -1,10 +1,27 @@
 import { Link } from 'react-router-dom';
+import { Seo } from '../../components/Seo';
 
 export default function OverdrawStereoLabPage() {
   const budgetMs = 11.11;
 
   return (
     <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
+      <Seo
+        title="Stereo Overdraw Lab — James De Raja"
+        description="Stereo overdraw lab evaluating double-eye transparency cost, fragment amplification, and GPU budget pressure in XR rendering."
+        url="https://james.alphaden.club/lab/overdraw-stereo"
+        keywords="stereo overdraw, XR rendering, fragment cost, Unity performance"
+        type="article"
+        structuredData={{
+          '@context': 'https://schema.org',
+          '@type': 'CreativeWork',
+          headline: 'Stereo Overdraw Lab',
+          description: 'Stereo overdraw lab evaluating double-eye transparency cost, fragment amplification, and GPU budget pressure in XR rendering.',
+          author: { '@type': 'Person', name: 'James De Raja' },
+          datePublished: '2025-01-01',
+          image: '/og-image.png',
+        }}
+      />
       <div style={{ marginBottom: '16px' }}>
         <Link to="/?section=writing">← Back to Writing</Link>
       </div>

--- a/src/lab/pages/XRFrameTimingLabPage.tsx
+++ b/src/lab/pages/XRFrameTimingLabPage.tsx
@@ -2,10 +2,27 @@ import { Link } from 'react-router-dom';
 import ResultsTable from '../../components/ResultsTable';
 import SmartLink from '../../components/SmartLink';
 import { performanceResults } from '../../data/performanceResults';
+import { Seo } from '../../components/Seo';
 
 export default function XRFrameTimingLabPage() {
   return (
     <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
+      <Seo
+        title="XR Frame Timing Lab — James De Raja"
+        description="Lab article on XR frame deadlines, compositor sync points, and practical profiling signals for reducing reprojection risk."
+        url="https://james.alphaden.club/lab/xr-frame-timing"
+        keywords="XR frame timing, compositor deadlines, reprojection, Unity XR"
+        type="article"
+        structuredData={{
+          '@context': 'https://schema.org',
+          '@type': 'CreativeWork',
+          headline: 'XR Frame Timing Lab',
+          description: 'Lab article on XR frame deadlines, compositor sync points, and practical profiling signals for reducing reprojection risk.',
+          author: { '@type': 'Person', name: 'James De Raja' },
+          datePublished: '2025-01-01',
+          image: '/og-image.png',
+        }}
+      />
       <div style={{ marginBottom: '16px' }}>
         <Link to="/?section=writing">← Back to Writing</Link>
       </div>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,16 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { HelmetProvider } from 'react-helmet-async';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App.tsx';
 import './index.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <HelmetProvider>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </HelmetProvider>
   </StrictMode>
 );

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -7,6 +7,7 @@ import WorkSection from '../sections/WorkSection';
 import WritingSection from '../sections/WritingSection';
 import XRLabSection from '../sections/XRLabSection';
 import ShippedTitlesSection from '../sections/ShippedTitlesSection';
+import { Seo } from '../components/Seo';
 
 export default function HomePage() {
   const location = useLocation();
@@ -27,6 +28,12 @@ export default function HomePage() {
 
   return (
     <div className="min-h-screen bg-site-pattern text-slate-900">
+      <Seo
+        title="James De Raja — Real-Time Performance Engineer"
+        description="Portfolio of James De Raja, senior real-time performance engineer specializing in Unity rendering, frame pacing discipline, and XR optimization."
+        url="https://james.alphaden.club/"
+        keywords="James De Raja, real-time performance engineer, Unity performance, XR optimization, frame pacing"
+      />
       <main>
         <HeroSection />
         <WorkSection />


### PR DESCRIPTION
### Motivation
- Replace placeholder Open Graph URL and strengthen the global head so the site is indexed for the production domain.
- Ensure each route provides unique, descriptive metadata and structured data so search engines and social crawlers see per-page titles/descriptions/OG cards.
- Improve accessibility and crawlability by adding descriptive alt text, ARIA attributes for data visuals/tables, and a complete sitemap for route discovery.

### Description
- Updated `index.html` head to use `https://james.alphaden.club/` with canonical, `robots`, `author`, `keywords`, full Open Graph and Twitter card tags, and `og:site_name`.
- Added `react-helmet-async`, created `src/components/Seo.tsx` (reusable SEO component supporting OG/Twitter/meta and JSON-LD), and wrapped the app with `HelmetProvider` in `src/main.tsx` so route-level metadata is injected at runtime.
- Integrated `<Seo />` usage into pages under `src/pages`, `src/caseStudies/pages` and `src/lab/pages` (including the `msaa-overdraw` landing/redirect), supplying unique `title`, `description`, `url`, `keywords`, `type`, and example `structuredData` for article/creativeWork pages.
- Expanded `public/sitemap.xml` to include all significant routes from `src/App.tsx`, and improved accessibility by updating `src/components/EvidenceCard.tsx` and `src/components/IconContainer.tsx` alt text and adding ARIA labels to `src/components/ResultsTable.tsx` and `src/components/charts/MiniBars.tsx`.

### Testing
- Ran `npm run lint` and the linter completed successfully in this environment.
- Ran `npm run build` and the production build completed successfully (built `dist` artifacts without errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7c74ef98c832499ebf64f8fc4a397)