### PR TITLE
Add SEO component + metadata, sitemap updates, resume generation, and accessibility tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,14 @@
     <title>James De Raja — Real-Time Performance Engineer (Unity/XR)</title>
     <meta
       name="description"
-      content="Senior real-time performance engineer focused on Unity rendering, frame pacing discipline, and XR performance research with profiler-backed measurements."
+      content="Senior real-time performance engineer specialising in Unity rendering, frame pacing discipline and XR performance research with profiler-backed measurements."
+    />
+    <link rel="canonical" href="https://james.alphaden.club/" />
+    <meta name="robots" content="index,follow" />
+    <meta name="author" content="James De Raja" />
+    <meta
+      name="keywords"
+      content="James De Raja, real-time performance engineer, Unity performance, XR optimisation, frame pacing, rendering cost isolation, GPU/CPU bottleneck"
     />
     <meta property="og:title" content="James De Raja — Real-Time Performance Engineer (Unity/XR)" />
     <meta
@@ -15,8 +22,16 @@
       content="Unity rendering, frame pacing, and XR performance research with profiler-backed measurements."
     />
     <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://james.alphaden.club/" />
     <meta property="og:image" content="/og-image.png" />
-    <meta property="og:url" content="https://example.vercel.app" />
+    <meta property="og:site_name" content="James De Raja Portfolio" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="James De Raja — Real-Time Performance Engineer (Unity/XR)" />
+    <meta
+      name="twitter:description"
+      content="Unity rendering, frame pacing, and XR performance research with profiler-backed measurements."
+    />
+    <meta name="twitter:image" content="/og-image.png" />
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "nodemailer": "^7.0.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-helmet-async": "^3.0.0",
         "react-router-dom": "^6.30.3"
       },
       "devDependencies": {
@@ -2923,6 +2924,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -3724,6 +3734,26 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-helmet-async": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-3.0.0.tgz",
+      "integrity": "sha512-nA3IEZfXiclgrz4KLxAhqJqIfFDuvzQwlKwpdmzZIuC1KNSghDEIXmyU0TKtbM+NafnkICcwx8CECFrZ/sL/1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "react-fast-compare": "^3.2.2",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3933,6 +3963,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "nodemailer": "^7.0.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-helmet-async": "^3.0.0",
     "react-router-dom": "^6.30.3"
   },
   "devDependencies": {

--- a/public/resume/JamesDeRaja_Resume_Performance-Systems.pdf
+++ b/public/resume/JamesDeRaja_Resume_Performance-Systems.pdf
@@ -1,0 +1,93 @@
+%PDF-1.3
+% ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 9 0 R /MediaBox [ 0 0 612 792 ] /Parent 8 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 8 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/PageMode /UseNone /Pages 8 0 R /Type /Catalog
+>>
+endobj
+7 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260304060307+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260304060307+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+8 0 obj
+<<
+/Count 2 /Kids [ 4 0 R 5 0 R ] /Type /Pages
+>>
+endobj
+9 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1836
+>>
+stream
+Gatm<?$"^Z'RfGR\20]?Zs*W`&4h%L)Vd/`&f<uZe![ki[K&1njHX7X1Ag,+8etfJ\(f<uA0q=emQJ-'k8^B/-hu0!^QTYq_[K]jgX,B(C_#iMZO=*D#\U@-oa\@`bqo7=C%H`P8_XD/lU(UcYNPEKAp>+e@2)$b]G\G9fiOR>ZAXA*:L'DbZhODXm@K:N;3EeK/>j%VSl3]*![^mlL!0j!."lua32I8eJd9Tn#6-kV0Tfhi1;)3`F75i=1P[u!f`8aLS173+^62h>k#*uI3G,f:$.2H9!K7E/5mmg_$Vait2R-el:ZCsZRs6-QSr8Pa!A(W2e=b?t+IXQ+Q6`<>R:Klf&?_E"<6"gI(/-C)f\gQ$QnOD3KW(r/gl`KT(1Q2(XB5)Sa*CjL;6;Q"*u9_'B:</u4i[/@h9>4c`bbjuX4&q(g+YrZ`qL-&f/p,(9crfkL=$g0'=Os5f+-/rDNq$/g/$?>O,]ji_hJf'J8mMfKVos;QteFSPcpGg4JuGb!)u5t7Pa[Hk*C!/BID>0>YQ8CQ]hZ1L"7.'1jR*Z,hj`%Bc'oTQ6rN#ahVAS9<9WX,Vcip-8BCkhD@ALS=N^br_Tmo6V95$3TEeIQ9_]\24HC5AANuq5ZRX369ZoEH<ZZ7#7o2bhV4<@N1Smo[:)[<6rOXI.T8piJIfPF`r`oC%Yn0Y1<u:c=9ojf8P**h#e%jj>nP10L"O,f'uS9gW)n8i.aFM9=]*PqPU%godg/cfLhmQQG[a,'b-druB2WG/1o[3q!'/RB$Q%<n(uT(-nQ;;Y+)p%N[-=1dZDSX7;iI5\[]ncn77K2?&C9X2e,RA[S[mRe*(M/G5@<=):9i]ofb?W*?[a(eUZp5h&)?!!Whg0W90f'Ca+`d<M`lSdq#7f3O,F/n0WXkT^KO"6>!A'q>o.da6LY1K[Dgd96hNI)!IV8,3MLN(=A\6`YHnn/(>6EZ2ld/]NI*adR,I4G^XKbRq=N[5`c5k5O^ChJ=[DS^e=J=^"CToW_73jDcF3[q.'%B@Vms<#BKE$$HlZ0?r),LdSI(E-*.\u%QCK6(7Gk@Mi.rk%`uKp]^sP]L@-PD;!B_\QV/X*m@GEQdAe.G1DCRm"%2*<R#,[g-Id2Of;@a6CbqR,F(SXs.@*boNnY:Bs"3q?6<[bj!`^D1I9\(uYKA\9`ZUSVkcjq_)V;2L-m]BX#Wg:+\'Z"*=K).3M^q&u";F2Hl47-"@VVuB:3=A>2$)<RAk\bWp)+&RtFaY?ddImGQ9VV%dhD+\RgUX7$D7jVCe>?DIV6!hs-cu!PG.qO`mg455(p#>0<R=9YOqEr-q$+QC653XCU.`E6,`tFh:hHV4<W%)<%@ilSX+YL-D=O`%rCi6XhMtEg6G+b[ml*=V'^*B-"HjQ=S$U8o6YY_-Mp+LkTqP-,ZCmmVl,M[^Y[R_F8_jV\\)KN6j%p?eP<J/P[Sf''4\^c,faBsis-sdWToF:qn#Y@[e/G\6[rd<Wd4[)MZ*a:CC\H-0g;a%fP0>sqmf@AKU;d3nLP\$tp?VF<gQBs#FDc58bNV5,@?74$a521!2q%9@1l=q*Er1)XpAnbD.Weu\R<BW]7*PdB6_m@o]Y7Lo6f2*BYk,SPHVs`VD*G2&OI">`0tQ`XR@k/3W;g(7gH,Km/@ERd)K*"d&s6b4Eo)Z2/'NPtmHJTI9>#i:0jBmsV`'\`'O,LI5,8b$OcWJgh.)^-m61fHFf?=(84[/\dd+t%gBIRna#pcs'rAnTBu@[n@_.'-mkI\bQXLa=8PN3h*"/Muk3K!WEt'kSCJ'#F[/5%Re#&5(gce4js(5Qa9>(85*Bgi6nEOpjAl[:~>endstream
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 900
+>>
+stream
+GatU19lo#B&A@g>lnN2V_2_7RYt7KAR7ta7B-rC=KY3$K[cC%9.@L21Y&$Df["jZ'$j(j%p%Id"lNfuXM:tg-!*:&.haS0rO;/<Q_Z[8,Qt@GoobaE:R'o'm_o_dN'S<+e>[HoG"Xhcsq/e?\hHs&S+a\e,iun[5+,(j-E;]GQdC9W@;`WFMK5rY9;eT)9-1UnAB,t"gVJ8O,dD5@qUE[1""c@>^;2*>on.XeYS34j^G](lKLd"'nE=6:W<t1E)o[9JeMC"O8gRo[!*TSJH8m=g6![EB8L^Lsq7;?r\B!m`f9W/qi:WW#>FR;l;#tJ/bNfksnYs>;odda-nrFlir@3RZlJsE:]%f:pl9LA;/?&G#ep&#CO5mlD9YK5$V2M\9Hq^\:AC?J4'=DfZHegHr^6c5FUB*qtQfbC93[Jl"HfZ'[%)fCM_+`X_#El7ZeUC/]7>4kKI)2Eke*5`C9V`0W=OeYoXUq.8PV:M+O2QV2N7017b.YMmZS-Gu1_\SZ-)MJPs!F7th0&SqG/ik;Ag7mE`kuZH7U[A-tZ!9BN*'*9)B^gj!<RO'f>:gd5S/&HWndasd+oT&$HIf?dK0<&=gp$s_1JPi[ou]9=DBKB)6])LmBE>gW>>\9Ng9Ut]5RXdVf"M,RkDc9Kfn]'=dLjc^5PL'704h!?8P")W$jjU5ARjFH?lIQ6Q)ng>4$-"mX#5,+Uh^C24mF_6:nb+Q&Y'Op_]/C=V6cb*9%2)LHQH>RXKR(I,>CWNdlVKg,;&lFmBGMkf/676VRlIbe#WQA7),BR;d2\llF!j,JKJWRC$9::\b&QUmM+l3RH&4Ap.*.&nA\+QR&;m(f3bi:\,.4cP0dr^4]s(UNU5O0N36]ZDu$:_H;jF@_=+H?G759OquS'B2[B~>endstream
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000000061 00000 n 
+0000000102 00000 n 
+0000000209 00000 n 
+0000000321 00000 n 
+0000000514 00000 n 
+0000000708 00000 n 
+0000000776 00000 n 
+0000001037 00000 n 
+0000001102 00000 n 
+0000003029 00000 n 
+trailer
+<<
+/ID 
+[<e5a1be00b381f18797082ddec368d670><e5a1be00b381f18797082ddec368d670>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 7 0 R
+/Root 6 0 R
+/Size 11
+>>
+startxref
+4020
+%%EOF

--- a/public/resume/JamesDeRaja_Resume_Unity-Rendering-Performance.pdf
+++ b/public/resume/JamesDeRaja_Resume_Unity-Rendering-Performance.pdf
@@ -1,0 +1,93 @@
+%PDF-1.3
+% ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 9 0 R /MediaBox [ 0 0 612 792 ] /Parent 8 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Contents 10 0 R /MediaBox [ 0 0 612 792 ] /Parent 8 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/PageMode /UseNone /Pages 8 0 R /Type /Catalog
+>>
+endobj
+7 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260304060307+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260304060307+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+8 0 obj
+<<
+/Count 2 /Kids [ 4 0 R 5 0 R ] /Type /Pages
+>>
+endobj
+9 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1811
+>>
+stream
+GatU4gMYb*&:O"K%'W"EDWI;H9B)jlCc-A#,_k[PVEeK:M72).Ud.h$*ULi8OHM8:d\>YD5QK!Obi-c+B1?T$'7X3ZGFS\=c(X[,"YChY$YZs6D4"*AR(ouRI;$%R*W+*,rSm<@Ws[9h6gl"eBCOklE#[#/'L4Xf)17,5GF8E@O+Ztl<?/d1I613)CZ@NrVRI+7Sl!Q('&LN9#ZE2h6=tnk'EZ!ZS5K[n_C%o1$<%St6&1]\bI1+_A;$e-pl<0)AgQ?V?VC!h*fCH59LMQ2'>+kM3TZn;U<A4eNR-?MZG\'Z7FNTT$E4gcAYK\cX`N$21b=GD8b3Zg.'L[*&KugCVEYmEiRF%T<=p*rN>qHo,8qb@4G^D6O9bmLU@//b>;kHlGoDb&;+"#@//$u=1`>le`m&*o:[M*#D$7l%gXQp?1IXLHpD[Z/SsT4a&%B$#n>j_A>O=@`p*R[8G^U!G#$X]q!ldN(P1DHWeu>e"1fGHoSApM`m+I'.,M1D"`c1e4Jur2(+qe(WPgfC6#Uek;0h`hd:dpBEfX'\8LF3^:=<6I'#>ge/d.83Cc-O_d<s^/Zp&^ZD!3:0<(B(7@WQ%c'b)C>;1lJ%Y@i$3'.@aOh+9Q[6(+_=F2F9SZ;R'(g2,&jkBF83CAKo79KA5'e!$o`d[U=)t+7kI"aI[<9`["8Y=d?:%TNBdQ"B5tE9I\1o!NaL$gL%O(W3hpQQ)7KKhe^:&S0j>SLo&U52g%*!WYS6^ocg@e8XYqg_OM65,5`*b9EU](<'.1$U8Wf5R8:9</dU2Xhkr@bQG[)\I<.fO@_&<*e]!#*Ln..-_tu-<fpD5>14sKe#4i^[$,6C[+-'sj5!#?R?^>!!_(0r>S6?,,)C1dWQAmcAh=C1jW]Zseo\9`KfE(E$,j#`RgTJD_Q8VEXiT_QN5p^94aIQoXH+GBGHPeKCjMD2NQH,;/f5U2SgMZ\aI(*^$?,jdNQ-#)B0P7MIa"<:cC]>t]=LlE7f>AEL^]_P>]TO:Q.4UCL$]uoTc()d(DM6^#H'no'?_s*7'a7)Op98Il'J)8/hLijN,S\7'Bj"u2CU>.QeIK+7.n4u]>BGZhohQ"7HXZKW:YI_ckJQ8TeN02cH,\sh>U-!''dghTXu(a:&.HU!C#YE8H8"[;ZUuW]3>!J0%S#V%?df0`,mh"uK"\gTX.B-!W*(e\L@\dUdieR1+5RLqL&hF$fAjIc#fh/@0FdJhnANNOY('S4qIHXtBh=SqbM,e.0;kf`g\m&$&\U'7&$1V,!3S($T7/Yr,9.^CQJgh]d;-D(-E?6\Yu__>eKV=HP1eP3W?+Enna(J2HTr[RO>rr[H?HuhW=q>0;MkoiCa!fY:W\okUKS;5Ee7;K[ruSjEQ_"Z0Xt9lTckb:U3;d55\p6eHg#o>T:NLbs4U4qIlHKghBU?c%9\utC90a@"iruF$rG(CTPF,>S^tuLl;/+Q>sc9fL:(,c6Q9"3VQl'Tq:.BCChaLrac^D:NRcpS4IZ/nI/VYqdNN>*Eq&UmHtrn0K%H$SPkpslPVY]V_:T))5<=Y6[GNmB4b0-l^ABOVP#cD0ZL+f_G(Y[O=fU&3]Wm'WQH+Sm.FJo_%N8D$n1&prR7t,D=l-\G[^G![`YlWu,:G?lNgqMl/$`d.kQj&8kNTF&/))u_B*@L-=U?#&DdcG7hM[b%#%V*1>gQL:bAk)aS[)agCOG8fmH.0b1V?4EAAXoM/H(-`PF774*2TS"ST]a=qVb"<XeBCgM>h$U!)[EW3N"LQB_Cg-I#F*gbK'*8`oV@[YJaU9Fhd2.AU5%2hYd[cj[h`~>endstream
+endobj
+10 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 906
+>>
+stream
+GatU195g:b&AIm?bV<i1JcKeOWC%k&GutB=HH9ZK0l-s(FEbQDeK<[OQ8j`T6UbS>QIdfHheV^h5qfGAb\DY]$-]S8n9dcMi!$FeOrK4@&,j$LSi7&SJ'MZLf71H,8/T/<)4fAu&qA`U&*s".'q[h`%?cdm,#iqE'_,h`hhu_V?Xta/Clgi6JZ[km!"\diihCr4Wh!*H',a+f$8)l)quVB,#>`&UD%p`rD+sPTh`%1EI:INHIproQfN,R>B"/OO8u!>O_k*>1XuG,2C9rUn)H3?Flku0ueNn7>!F@]WG.,7_Yo9<ERJjri5%;HDkt#uolp+N"PCbh5'\QnQVWN.X^tpKMit\8R*NEALr<.![0.nSp=O:ngF0.%jL)GV9BP=g@mfXPH<rL!=rHss![REJP7REl[<88%a@n)Cm%Q=?<)U\`;aE4Ib>+t&EAS)YG+<#c;U?7.Pi&ME(,*hBQ)0Dt>\J)Va>#X`.#dH1aMD[Cg!uG@uJrE\E.IK;#VGtWW8?l\G@@rLDr62^79K%R^7`pHRfAf,CNljj+1t82S0h+qd[k]6Ei=klneMQ51j"YjUVgZk'5%ccl,Pm1f?V"Nc$HZEgAS,+SLXhm,2/cr!MCZnT(S"6`-s$.Fc?mkXK/R>AV'A!3-7c(6S-s24[;Dk%@Kq`ffa=M9Mo@Y+K[^.VDMjmFB*O"@g#$#rrH=n#k>qMX&"&o$0@fZsP']@?;ISc%YE3L&=tQ3mm>nPblIkEq8&5WM"5Lq[2[t=dUZ.NhZDJ'rl)C5qoRXGO4hrUPAp4_42<bT[S^B<*c3]3<QKg0=?N#)669cB=(\Er2]1e@UK['96JH+T%(CY2A0=S!?A:8qd@]3\e^K6`!$EVS0cCnh!e%n*Al5eb?FKFtYMsnOo++=<f5rCn~>endstream
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000000061 00000 n 
+0000000102 00000 n 
+0000000209 00000 n 
+0000000321 00000 n 
+0000000514 00000 n 
+0000000708 00000 n 
+0000000776 00000 n 
+0000001037 00000 n 
+0000001102 00000 n 
+0000003004 00000 n 
+trailer
+<<
+/ID 
+[<028b635052ee68b0be0328d4ccf50c77><028b635052ee68b0be0328d4ccf50c77>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 7 0 R
+/Root 6 0 R
+/Size 11
+>>
+startxref
+4001
+%%EOF

--- a/public/resume/JamesDeRaja_Resume_XR-Performance-Engineer.pdf
+++ b/public/resume/JamesDeRaja_Resume_XR-Performance-Engineer.pdf
@@ -81,7 +81,7 @@ xref
 trailer
 <<
 /ID 
-[<43d833aed9e447718679d6b0ac0766ef><43d833aed9e447718679d6b0ac0766ef>]
+[<ee2fbaa268dc9171eed36726e9ad2f70><ee2fbaa268dc9171eed36726e9ad2f70>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 7 0 R

--- a/public/resume/src/JamesDeRaja_Resume_Performance-Systems.md
+++ b/public/resume/src/JamesDeRaja_Resume_Performance-Systems.md
@@ -1,0 +1,55 @@
+# James De Raja
+
+Real-Time Rendering Performance Engineer | Unity | XR Profiling
+
+Email: jamesderaja@gmail.com | Location: Open to Remote/Hybrid
+**Portfolio:** https://james.alphaden.club | **GitHub:** https://github.com/JamesDeRaja | **XR Lab Repo:** https://github.com/JamesDeRaja/XRPerformanceLab | **LinkedIn:** https://www.linkedin.com/in/james-de-raja
+
+## Summary
+
+Performance/Systems Engineer with 10+ years in Unity and real-time environments, specializing in GPU/CPU bottleneck analysis, instrumentation, and frame pacing stability.
+Built deterministic profiling and diagnostics frameworks (Unity 6 URP + OpenXR) to isolate overdraw, MSAA, submission overhead, and frame timing variance with evidence.
+Shipped production systems with an observability-first mindset: metrics, diagnostics, reproducible experiments, and mitigation playbooks.
+
+## Core Skills (ATS Keywords)
+
+- Real-Time Performance Optimization
+- GPU / CPU Bottleneck Analysis
+- Profiling & Diagnostics (Unity Profiler, Frame Debugger)
+- XR Frame Timing & Frame Pacing (72/90Hz)
+- Unity Rendering Pipelines (URP, Built-in)
+- Memory & GC Optimization (C#, Unity)
+
+Tools / Technical: Unity 6, OpenXR, RenderDoc, Android Profiling, Xcode Instruments, Git
+
+**Keywords:** XR performance, frame pacing, frame timing, rendering optimization, overdraw, MSAA, draw calls, batching/instancing, CPU main thread, render thread, GPU RenderLoop, profiling, performance instrumentation.
+
+## Selected Performance Engineering Projects
+
+**XR Performance Stress Lab (Unity 6 URP + OpenXR)**
+- Built deterministic experiments and instrumentation to classify GPU/CPU bottleneck signatures across overdraw, MSAA, and submission scenarios.
+- Measured **+7.27ms** GPU RenderLoop amplification under overdraw and validated findings via Unity Profiler and Frame Debugger evidence.
+- Standardized mitigation mapping by bottleneck type to improve triage speed and decision quality across performance incidents.
+  Tech: Unity 6, URP, OpenXR, Unity Profiler, Frame Debugger
+
+**Profiling Toolkit / Runtime Diagnostics Overlay**
+- Designed runtime instrumentation for frame timing and variance signals to improve observability during active performance incidents.
+- Automated evidence collection conventions to reduce ambiguity and accelerate root-cause analysis with reproducible captures.
+- Validated mitigation outcomes against deterministic baselines to prevent regression drift between iterations.
+  Tech: Unity, C#, Unity Profiler, Frame Debugger, Git
+
+## Experience
+
+**Independent Performance/Systems Engineer (Unity Real-Time)** | 2024–Present
+- Built observability-first diagnostics for frame timing, frame pacing, and rendering optimization decisions in XR and real-time scenes.
+- Diagnosed CPU main thread, render thread, and GPU bottlenecks using deterministic workflows and evidence-backed profiling.
+- Standardized mitigation playbooks and handoff artifacts to improve repeatability of performance investigations.
+
+**Senior Unity Engineer (Performance + Reliability Focus)** | 2014–2024
+- Improved stability by instrumenting performance-critical systems and validating fixes with reproducible CPU/GPU profiling.
+- Reduced recurring runtime issues through structured diagnostics, measurable triage workflows, and validation gates.
+- Led performance optimization efforts for shipped mobile projects with emphasis on frame-time stability and maintainability.
+
+## Education
+
+Formal education details available upon request.

--- a/public/resume/src/JamesDeRaja_Resume_Unity-Rendering-Performance.md
+++ b/public/resume/src/JamesDeRaja_Resume_Unity-Rendering-Performance.md
@@ -1,0 +1,55 @@
+# James De Raja
+
+Unity Rendering & XR Performance Engineer | Frame Pacing
+
+Email: jamesderaja@gmail.com | Location: Open to Remote/Hybrid
+**Portfolio:** https://james.alphaden.club | **GitHub:** https://github.com/JamesDeRaja | **XR Lab Repo:** https://github.com/JamesDeRaja/XRPerformanceLab | **LinkedIn:** https://www.linkedin.com/in/james-de-raja
+
+## Summary
+
+Unity Rendering Performance Engineer with 10+ years in real-time systems, specializing in GPU/CPU bottleneck analysis, rendering optimization, and frame pacing under 72/90Hz frame deadlines.
+Built deterministic Unity 6 URP + OpenXR profiling workflows to isolate overdraw, MSAA amplification, draw calls, and render thread submission overhead with evidence.
+Shipped mobile and XR performance-critical work with a repeatable CPU/GPU profiling mindset using Unity Profiler and Frame Debugger.
+
+## Core Skills (ATS Keywords)
+
+- Unity Rendering Pipelines (URP, Built-in)
+- Real-Time Performance Optimization
+- GPU / CPU Bottleneck Analysis
+- Profiling & Diagnostics (Unity Profiler, Frame Debugger)
+- XR Frame Timing & Frame Pacing (72/90Hz)
+- Memory & GC Optimization (C#, Unity)
+
+Tools / Technical: Unity 6, URP, OpenXR, RenderDoc, Android Profiling, Xcode Instruments, Git
+
+**Keywords:** XR performance, frame pacing, frame timing, rendering optimization, overdraw, MSAA, draw calls, batching/instancing, CPU main thread, render thread, GPU RenderLoop, profiling, performance instrumentation.
+
+## Selected Performance Engineering Projects
+
+**XR Performance Stress Lab (Unity 6 URP + OpenXR)**
+- Built deterministic rendering benchmarks to isolate overdraw, MSAA bandwidth cost, submission overhead, and frame pacing variance in XR.
+- Measured **+7.27ms** GPU RenderLoop growth from layered transparency and validated root cause with Unity Profiler + Frame Debugger evidence.
+- Validated mitigation options for draw calls, instancing / batching, and transparent pass pressure to protect frame timing budgets.
+  Tech: Unity 6, URP, OpenXR, Unity Profiler, Frame Debugger
+
+**Instancing vs Non-Instancing Lab (Submission Cost Isolation)**
+- Diagnosed render thread pressure in high draw-call scenes via CPU/GPU profiling and controlled A/B scene conditions.
+- Improved CPU submission behavior by applying instancing strategy and verifying reduced frame-time pressure in profiler captures.
+- Standardized experiment notes and evidence bundles to make rendering optimization outcomes reproducible.
+  Tech: Unity, URP, C#, Unity Profiler
+
+## Experience
+
+**Independent Unity Rendering Performance Engineer** | 2024–Present
+- Optimized rendering optimization hotspots with GPU/CPU bottleneck analysis, improving frame pacing and frame timing consistency.
+- Profiled overdraw, MSAA, and submission patterns using Unity Profiler and Frame Debugger to prioritize fixes by measurable impact.
+- Designed deterministic validation passes to prove improvements in draw calls, render thread behavior, and GPU RenderLoop cost.
+
+**Senior Unity Engineer (Mobile + Real-Time Rendering)** | 2014–2024
+- Improved scene-level rendering performance by reducing avoidable draw calls and improving batching/instancing strategy.
+- Diagnosed CPU main thread and render thread hotspots with CPU/GPU profiling workflows and reproducible benchmark scenes.
+- Shipped performance-sensitive mobile systems with guardrails for stability, memory/GC behavior, and regression prevention.
+
+## Education
+
+Formal education details available upon request.

--- a/public/resume/src/JamesDeRaja_Resume_XR-Performance-Engineer.md
+++ b/public/resume/src/JamesDeRaja_Resume_XR-Performance-Engineer.md
@@ -1,0 +1,55 @@
+# James De Raja
+
+Senior Real-Time Performance Engineer | Unity | XR Rendering
+
+Email: jamesderaja@gmail.com | Location: Open to Remote/Hybrid
+**Portfolio:** https://james.alphaden.club | **GitHub:** https://github.com/JamesDeRaja | **XR Lab Repo:** https://github.com/JamesDeRaja/XRPerformanceLab | **LinkedIn:** https://www.linkedin.com/in/james-de-raja
+
+## Summary
+
+Senior Real-Time Performance Engineer with 10+ years in Unity, specializing in GPU/CPU bottleneck analysis, frame pacing, and XR frame timing under 72/90Hz deadlines.
+Built deterministic profiling frameworks (Unity 6 URP + OpenXR) to isolate overdraw, MSAA bandwidth, submission overhead, and variance — backed by profiler/Frame Debugger evidence.
+Shipped mobile titles and performance-critical systems; strong instrumentation mindset (metrics, diagnostics, reproducible experiments).
+
+## Core Skills (ATS Keywords)
+
+- Real-Time Performance Optimization
+- GPU / CPU Bottleneck Analysis
+- XR Frame Timing & Frame Pacing (72/90Hz)
+- Unity Rendering Pipelines (URP, Built-in)
+- Profiling & Diagnostics (Unity Profiler, Frame Debugger)
+- Memory & GC Optimization (C#, Unity)
+
+Tools / Technical: Unity 6, OpenXR, RenderDoc, Android Profiling, Xcode Instruments, Git
+
+**Keywords:** XR performance, frame pacing, frame timing, rendering optimization, overdraw, MSAA, draw calls, batching/instancing, CPU main thread, render thread, GPU RenderLoop, profiling, performance instrumentation.
+
+## Selected Performance Engineering Projects
+
+**XR Performance Stress Lab (Unity 6 URP + OpenXR)**
+- Built a deterministic XR benchmarking harness to isolate GPU fragment cost, MSAA bandwidth amplification, submission overhead, and frame pacing variance.
+- Measured **+7.27ms** GPU RenderLoop amplification under layered transparency (overdraw stress), validated via Unity Profiler comparisons and Frame Debugger evidence.
+- Produced a mitigation playbook mapped to bottleneck signatures (fragment-bound, bandwidth-bound, submission-bound, variance).
+  Tech: Unity 6, URP, OpenXR, Unity Profiler, Frame Debugger
+
+**SoftMaskPro Performance Study (Unity UI Rendering)**
+- Diagnosed masking-induced draw-call scaling with CPU/GPU profiling and Frame Debugger pass inspection across controlled scenarios.
+- Reduced rendering overhead by replacing expensive update paths and validating lower UI rebuild pressure with evidence-based profiling.
+- Standardized repeatable scenario captures to validate rendering optimization changes before and after patches.
+  Tech: Unity, URP, Unity Profiler, Frame Debugger, C#
+
+## Experience
+
+**Independent Real-Time Performance Engineer (Unity/XR)** | 2024–Present
+- Optimized XR performance workloads through GPU/CPU bottleneck analysis and evidence-based profiling, improving frame pacing stability under stress.
+- Instrumented deterministic experiments for overdraw, MSAA, instancing / batching, and draw calls to classify frame timing regressions before release.
+- Validated mitigation strategies with Unity Profiler and Frame Debugger captures, then documented repeatable workflows for engineering handoff.
+
+**Senior Unity Engineer (Mobile Performance Focus)** | 2014–2024
+- Profiled and improved frame-time hotspots in production mobile gameplay loops, reducing CPU main thread spikes and improving stability.
+- Designed rendering optimization changes for submission-heavy scenes, improving render thread behavior through batching/instancing decisions.
+- Shipped mobile titles with performance guardrails and reproducible profiling baselines to prevent regressions during content scaling.
+
+## Education
+
+Formal education details available upon request.

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,12 +1,73 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset 
-  xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://james.alphaden.club/</loc>
-    <lastmod>2025-07-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
-  
+  <url>
+    <loc>https://james.alphaden.club/case-studies/xr-stress-lab</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://james.alphaden.club/case-studies/softmaskpro</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://james.alphaden.club/case-studies/profiling-toolkit</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://james.alphaden.club/case-studies/sneaky-warrior-3d</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://james.alphaden.club/case-studies/published-mobile-projects</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://james.alphaden.club/lab/overdraw</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://james.alphaden.club/lab/msaa</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://james.alphaden.club/lab/msaa-overdraw</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://james.alphaden.club/lab/instancing</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://james.alphaden.club/lab/frame-pacing</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://james.alphaden.club/lab/frame-pacing-vs-fps</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://james.alphaden.club/lab/xr-frame-timing</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://james.alphaden.club/lab/overdraw-stereo</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
 </urlset>

--- a/scripts/generate_resumes.py
+++ b/scripts/generate_resumes.py
@@ -1,0 +1,97 @@
+from pathlib import Path
+from reportlab.lib.pagesizes import LETTER
+from reportlab.pdfgen import canvas
+from reportlab.lib.units import inch
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / 'public' / 'resume' / 'src'
+OUT = ROOT / 'public' / 'resume'
+
+FILES = [
+    ('JamesDeRaja_Resume_XR-Performance-Engineer.md', 'JamesDeRaja_Resume.pdf'),
+    ('JamesDeRaja_Resume_XR-Performance-Engineer.md', 'JamesDeRaja_Resume_XR-Performance-Engineer.pdf'),
+    ('JamesDeRaja_Resume_Unity-Rendering-Performance.md', 'JamesDeRaja_Resume_Unity-Rendering-Performance.pdf'),
+    ('JamesDeRaja_Resume_Performance-Systems.md', 'JamesDeRaja_Resume_Performance-Systems.pdf'),
+]
+
+def markdown_to_lines(text: str):
+    lines = []
+    for raw in text.splitlines():
+        line = raw.strip().replace('**', '')
+        if not line:
+            lines.append('')
+            continue
+        if line.startswith('# '):
+            lines.append(line[2:].upper())
+            continue
+        if line.startswith('## '):
+            lines.append('')
+            lines.append(line[3:].upper())
+            continue
+        if line.startswith('- '):
+            lines.append(f'- {line[2:]}')
+            continue
+        lines.append(line)
+    return lines
+
+
+def write_pdf(lines, path: Path):
+    c = canvas.Canvas(str(path), pagesize=LETTER)
+    width, height = LETTER
+    left = 0.75 * inch
+    top = height - 0.75 * inch
+    y = top
+
+    for line in lines:
+        font = 'Helvetica'
+        size = 10.5
+        if line.isupper() and len(line.split()) <= 8:
+            font = 'Helvetica-Bold'
+            size = 11.5
+        if line == '':
+            y -= 8
+            if y < 0.75 * inch:
+                c.showPage()
+                y = top
+            continue
+
+        # basic wrapping
+        words = line.split(' ')
+        current = ''
+        for word in words:
+            candidate = (current + ' ' + word).strip()
+            if c.stringWidth(candidate, font, size) <= (width - 1.5 * inch):
+                current = candidate
+            else:
+                c.setFont(font, size)
+                c.drawString(left, y, current)
+                y -= 14
+                if y < 0.75 * inch:
+                    c.showPage()
+                    y = top
+                current = word
+        if current:
+            c.setFont(font, size)
+            c.drawString(left, y, current)
+            y -= 14
+            if y < 0.75 * inch:
+                c.showPage()
+                y = top
+
+    c.save()
+
+
+def main():
+    try:
+        import reportlab  # noqa
+    except Exception as exc:
+        raise SystemExit('reportlab is required') from exc
+
+    for src_name, out_name in FILES:
+        text = (SRC / src_name).read_text(encoding='utf-8')
+        lines = markdown_to_lines(text)
+        write_pdf(lines, OUT / out_name)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/caseStudies/pages/ProfilingToolkitCaseStudyPage.tsx
+++ b/src/caseStudies/pages/ProfilingToolkitCaseStudyPage.tsx
@@ -1,9 +1,27 @@
 import { Link } from 'react-router-dom';
 import SmartLink from '../../components/SmartLink';
+import { Seo } from '../../components/Seo';
 
 export default function ProfilingToolkitCaseStudyPage() {
   return (
     <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
+      <Seo
+        title="Profiling Toolkit Case Study — James De Raja"
+        description="Case study on a Unity runtime profiling overlay that shortens bottleneck triage from symptom capture to mitigation-ready evidence."
+        url="https://james.alphaden.club/case-studies/profiling-toolkit"
+        keywords="Unity profiler toolkit, runtime overlay, bottleneck triage, performance telemetry"
+        type="article"
+        structuredData={{
+          '@context': 'https://schema.org',
+          '@type': 'Article',
+          headline: 'Profiling Toolkit Case Study',
+          description:
+            'Case study on a Unity runtime profiling overlay that shortens bottleneck triage from symptom capture to mitigation-ready evidence.',
+          author: { '@type': 'Person', name: 'James De Raja' },
+          datePublished: '2025-01-01',
+          image: '/og-image.png',
+        }}
+      />
       <div style={{ marginBottom: '16px' }}>
         <Link to="/">← Back to Home</Link>
       </div>

--- a/src/caseStudies/pages/PublishedMobileProjectsCaseStudyPage.tsx
+++ b/src/caseStudies/pages/PublishedMobileProjectsCaseStudyPage.tsx
@@ -1,9 +1,27 @@
 import { Link } from 'react-router-dom';
 import SmartLink from '../../components/SmartLink';
+import { Seo } from '../../components/Seo';
 
 export default function PublishedMobileProjectsCaseStudyPage() {
   return (
     <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
+      <Seo
+        title="Sneaky Warrior 3D Case Study — James De Raja"
+        description="Mobile performance case study covering frame budget stabilization for Sneaky Warrior 3D under heavy AI, ragdoll, and projectile load."
+        url="https://james.alphaden.club/case-studies/published-mobile-projects"
+        keywords="mobile performance, Unity optimization, frame budget, Sneaky Warrior 3D, frame pacing"
+        type="article"
+        structuredData={{
+          '@context': 'https://schema.org',
+          '@type': 'Article',
+          headline: 'Sneaky Warrior 3D Frame Budget Stabilization',
+          description:
+            'Mobile performance case study covering frame budget stabilization for Sneaky Warrior 3D under heavy AI, ragdoll, and projectile load.',
+          author: { '@type': 'Person', name: 'James De Raja' },
+          datePublished: '2025-01-01',
+          image: '/og-image.png',
+        }}
+      />
       <div style={{ marginBottom: '16px' }}>
         <Link to="/">← Back to Home</Link>
       </div>

--- a/src/caseStudies/pages/SoftMaskProCaseStudyPage.tsx
+++ b/src/caseStudies/pages/SoftMaskProCaseStudyPage.tsx
@@ -1,9 +1,27 @@
 import { Link } from 'react-router-dom';
 import SmartLink from '../../components/SmartLink';
+import { Seo } from '../../components/Seo';
 
 export default function SoftMaskProCaseStudyPage() {
   return (
     <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
+      <Seo
+        title="SoftMaskPro Optimization Case Study — James De Raja"
+        description="SoftMaskPro profiling and patching case study focused on UI mask draw calls, render pass overhead, and frame-time stabilization in Unity."
+        url="https://james.alphaden.club/case-studies/softmaskpro"
+        keywords="SoftMaskPro, Unity UI optimization, draw calls, frame timing, profiling"
+        type="article"
+        structuredData={{
+          '@context': 'https://schema.org',
+          '@type': 'Article',
+          headline: 'SoftMaskPro Optimization Case Study',
+          description:
+            'SoftMaskPro profiling and patching case study focused on UI mask draw calls, render pass overhead, and frame-time stabilization in Unity.',
+          author: { '@type': 'Person', name: 'James De Raja' },
+          datePublished: '2025-01-01',
+          image: '/og-image.png',
+        }}
+      />
       <div style={{ marginBottom: '16px' }}>
         <Link to="/">← Back to Home</Link>
       </div>

--- a/src/caseStudies/pages/XRStressLabCaseStudyPage.tsx
+++ b/src/caseStudies/pages/XRStressLabCaseStudyPage.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import SmartLink from '../../components/SmartLink';
 import MiniBars from '../../components/charts/MiniBars';
 import { getResultDelta, xrStressLabResults } from '../../data/xrStressLabResults';
+import { Seo } from '../../components/Seo';
 
 function formatDelta(value: number | null) {
   if (value === null) {
@@ -14,6 +15,23 @@ function formatDelta(value: number | null) {
 export default function XRStressLabCaseStudyPage() {
   return (
     <div className="min-h-screen bg-site-pattern">
+      <Seo
+        title="XR Stress Lab Case Study — James De Raja"
+        description="Controlled XR stress tests isolating overdraw, MSAA bandwidth, submission overhead, and frame pacing variance with profiler-backed evidence."
+        url="https://james.alphaden.club/case-studies/xr-stress-lab"
+        keywords="XR stress lab, overdraw, MSAA, instancing, frame pacing, Unity profiling"
+        type="article"
+        structuredData={{
+          '@context': 'https://schema.org',
+          '@type': 'Article',
+          headline: 'XR Stress Lab Case Study',
+          description:
+            'Controlled XR stress tests isolating overdraw, MSAA bandwidth, submission overhead, and frame pacing variance with profiler-backed evidence.',
+          author: { '@type': 'Person', name: 'James De Raja' },
+          datePublished: '2025-01-01',
+          image: '/og-image.png',
+        }}
+      />
       <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
         <div style={{ marginBottom: '16px' }}>
           <Link to="/">← Back to Home</Link>

--- a/src/components/EvidenceCard.tsx
+++ b/src/components/EvidenceCard.tsx
@@ -22,7 +22,7 @@ export default function EvidenceCard({ title, description, imagePath, caption }:
         ) : (
           <img
             src={imagePath}
-            alt={title}
+            alt={`${title} evidence screenshot`}
             loading="lazy"
             onError={() => setImageMissing(true)}
             className="h-full w-full object-cover"

--- a/src/components/IconContainer.tsx
+++ b/src/components/IconContainer.tsx
@@ -6,7 +6,7 @@ const IconContainer = () => {
     <div className="w-12 h-12 bg-white/30 rounded-full flex items-center justify-center shadow-lg backdrop-blur-sm">
       <img 
         src="/images/Icon_3.png" 
-        alt="Custom Icon" 
+        alt="Performance metrics icon" 
         className="w-12 h-12"
       />
     </div>

--- a/src/components/ResultsTable.tsx
+++ b/src/components/ResultsTable.tsx
@@ -18,7 +18,7 @@ function formatBottleneck(bottleneck: string) {
 export default function ResultsTable({ rows }: ResultsTableProps) {
   return (
     <div className="overflow-x-auto rounded-2xl border border-slate-200 bg-white shadow-sm">
-      <table className="min-w-full divide-y divide-slate-200 text-left text-sm">
+      <table className="min-w-full divide-y divide-slate-200 text-left text-sm" aria-label="XR performance experiment results">
         <thead className="bg-slate-50 text-xs uppercase tracking-wide text-slate-600">
           <tr>
             <th className="px-4 py-3">Experiment</th>

--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -1,0 +1,60 @@
+import { Helmet } from 'react-helmet-async';
+
+type JsonLd = Record<string, unknown> | Array<Record<string, unknown>>;
+
+export type SEOProps = {
+  title: string;
+  description: string;
+  url: string;
+  image?: string;
+  keywords?: string;
+  type?: string;
+  structuredData?: JsonLd;
+};
+
+export function Seo({
+  title,
+  description,
+  url,
+  image = '/og-image.png',
+  keywords,
+  type = 'website',
+  structuredData,
+}: SEOProps) {
+  const personSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: 'James De Raja',
+    jobTitle: 'Senior Real-Time Performance Engineer',
+    url,
+    sameAs: ['https://github.com/JamesDeRaja'],
+  };
+
+  const schemas = structuredData
+    ? [personSchema, ...(Array.isArray(structuredData) ? structuredData : [structuredData])]
+    : [personSchema];
+
+  return (
+    <Helmet>
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      {keywords && <meta name="keywords" content={keywords} />}
+      <link rel="canonical" href={url} />
+      <meta name="robots" content="index,follow" />
+      <meta name="author" content="James De Raja" />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:type" content={type} />
+      <meta property="og:url" content={url} />
+      <meta property="og:image" content={image} />
+      <meta property="og:site_name" content="James De Raja Portfolio" />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+      <meta name="twitter:image" content={image} />
+      {schemas.map((schema, index) => (
+        <script key={index} type="application/ld+json">{JSON.stringify(schema)}</script>
+      ))}
+    </Helmet>
+  );
+}

--- a/src/components/charts/MiniBars.tsx
+++ b/src/components/charts/MiniBars.tsx
@@ -27,7 +27,13 @@ export default function MiniBars({
   const delta = stressMs === undefined ? null : stressMs - baselineMs;
 
   return (
-    <article className="rounded-xl border border-slate-200 bg-white p-3">
+    <article
+      className="rounded-xl border border-slate-200 bg-white p-3"
+      role="img"
+      aria-label={`${title}: ${labelLeft} ${baselineMs.toFixed(2)} milliseconds${
+        stressMs === undefined ? '' : `, ${labelRight} ${stressMs.toFixed(2)} milliseconds`
+      }`}
+    >
       <p className="text-sm font-medium text-slate-900">{title}</p>
       <div className="mt-3 space-y-2">
         <div className="grid grid-cols-[68px_1fr_auto] items-center gap-2">
@@ -42,7 +48,10 @@ export default function MiniBars({
           <div className="grid grid-cols-[68px_1fr_auto] items-center gap-2">
             <span className="text-xs text-slate-600">{labelRight}</span>
             <div className="h-2.5 rounded-full bg-slate-100">
-              <div className={`h-2.5 rounded-full ${variant === 'gpu' ? 'bg-cyan-600' : 'bg-slate-600'}`} style={{ width: `${stressWidth}%` }} />
+              <div
+                className={`h-2.5 rounded-full ${variant === 'gpu' ? 'bg-cyan-600' : 'bg-slate-600'}`}
+                style={{ width: `${stressWidth}%` }}
+              />
             </div>
             <span className="text-xs text-slate-700">{stressMs.toFixed(2)} ms</span>
           </div>

--- a/src/lab/pages/FramePacingLabPage.tsx
+++ b/src/lab/pages/FramePacingLabPage.tsx
@@ -1,8 +1,25 @@
 import { Link } from 'react-router-dom';
+import { Seo } from '../../components/Seo';
 
 export default function FramePacingLabPage() {
   return (
     <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
+      <Seo
+        title="Frame Pacing Lab — James De Raja"
+        description="Frame pacing lab focused on variance, spikes, and cadence stability beyond average FPS using profiler-backed measurements."
+        url="https://james.alphaden.club/lab/frame-pacing"
+        keywords="frame pacing, frame variance, Unity profiler, stutter analysis"
+        type="article"
+        structuredData={{
+          '@context': 'https://schema.org',
+          '@type': 'CreativeWork',
+          headline: 'Frame Pacing Lab',
+          description: 'Frame pacing lab focused on variance, spikes, and cadence stability beyond average FPS using profiler-backed measurements.',
+          author: { '@type': 'Person', name: 'James De Raja' },
+          datePublished: '2025-01-01',
+          image: '/og-image.png',
+        }}
+      />
       <div style={{ marginBottom: '16px' }}>
         <Link to="/case-studies/xr-stress-lab">← Back to XR Stress Lab Case Study</Link>
       </div>

--- a/src/lab/pages/FramePacingVsFPSLabPage.tsx
+++ b/src/lab/pages/FramePacingVsFPSLabPage.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import { Seo } from '../../components/Seo';
 
 export default function FramePacingVsFPSLabPage() {
   const hz = 72;
@@ -7,6 +8,22 @@ export default function FramePacingVsFPSLabPage() {
 
   return (
     <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
+      <Seo
+        title="Frame Pacing vs FPS Lab — James De Raja"
+        description="Lab article showing why stable frame pacing can outperform higher but inconsistent FPS in XR and real-time rendering workloads."
+        url="https://james.alphaden.club/lab/frame-pacing-vs-fps"
+        keywords="frame pacing vs FPS, XR performance, frame stability, Unity"
+        type="article"
+        structuredData={{
+          '@context': 'https://schema.org',
+          '@type': 'CreativeWork',
+          headline: 'Frame Pacing vs FPS Lab',
+          description: 'Lab article showing why stable frame pacing can outperform higher but inconsistent FPS in XR and real-time rendering workloads.',
+          author: { '@type': 'Person', name: 'James De Raja' },
+          datePublished: '2025-01-01',
+          image: '/og-image.png',
+        }}
+      />
       <div style={{ marginBottom: '16px' }}>
         <Link to="/?section=writing">← Back to Writing</Link>
       </div>

--- a/src/lab/pages/InstancingLabPage.tsx
+++ b/src/lab/pages/InstancingLabPage.tsx
@@ -1,9 +1,26 @@
 import { Link } from 'react-router-dom';
 import MetricsSummary from '../components/MetricsSummary';
+import { Seo } from '../../components/Seo';
 
 export default function InstancingLabPage() {
   return (
     <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
+      <Seo
+        title="Instancing Lab — James De Raja"
+        description="Instancing lab comparing draw submission overhead and CPU render-thread savings between instanced and non-instanced scenes."
+        url="https://james.alphaden.club/lab/instancing"
+        keywords="instancing lab, draw calls, render thread, Unity optimization"
+        type="article"
+        structuredData={{
+          '@context': 'https://schema.org',
+          '@type': 'CreativeWork',
+          headline: 'Instancing Lab',
+          description: 'Instancing lab comparing draw submission overhead and CPU render-thread savings between instanced and non-instanced scenes.',
+          author: { '@type': 'Person', name: 'James De Raja' },
+          datePublished: '2025-01-01',
+          image: '/og-image.png',
+        }}
+      />
       <div style={{ marginBottom: '16px' }}>
         <Link to="/case-studies/xr-stress-lab">← Back to XR Stress Lab Case Study</Link>
       </div>

--- a/src/lab/pages/MSAALabPage.tsx
+++ b/src/lab/pages/MSAALabPage.tsx
@@ -1,9 +1,26 @@
 import { Link } from 'react-router-dom';
 import MetricsSummary from '../components/MetricsSummary';
+import { Seo } from '../../components/Seo';
 
 export default function MSAALabPage() {
   return (
     <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
+      <Seo
+        title="MSAA Scaling Lab — James De Raja"
+        description="MSAA scaling lab measuring GPU bandwidth amplification and frame-time impact across anti-aliasing levels in controlled Unity scenes."
+        url="https://james.alphaden.club/lab/msaa"
+        keywords="MSAA scaling, Unity performance, GPU bandwidth, anti-aliasing"
+        type="article"
+        structuredData={{
+          '@context': 'https://schema.org',
+          '@type': 'CreativeWork',
+          headline: 'MSAA Scaling Lab',
+          description: 'MSAA scaling lab measuring GPU bandwidth amplification and frame-time impact across anti-aliasing levels in controlled Unity scenes.',
+          author: { '@type': 'Person', name: 'James De Raja' },
+          datePublished: '2025-01-01',
+          image: '/og-image.png',
+        }}
+      />
       <div style={{ marginBottom: '16px' }}>
         <Link to="/case-studies/xr-stress-lab">← Back to XR Stress Lab Case Study</Link>
       </div>

--- a/src/lab/pages/MSAAOverdrawLabPage.tsx
+++ b/src/lab/pages/MSAAOverdrawLabPage.tsx
@@ -1,5 +1,27 @@
 import { Navigate } from 'react-router-dom';
+import { Seo } from '../../components/Seo';
 
 export default function MSAAOverdrawLabPage() {
-  return <Navigate to="/lab/msaa#msaa-overdraw" replace />;
+  return (
+    <>
+      <Seo
+        title="MSAA + Overdraw Lab — James De Raja"
+        description="Landing route for the MSAA-overdraw interaction study covering compounded bandwidth and fragment pressure in Unity XR rendering."
+        url="https://james.alphaden.club/lab/msaa-overdraw"
+        keywords="MSAA overdraw, Unity XR, bandwidth amplification, fragment bottleneck"
+        type="article"
+        structuredData={{
+          '@context': 'https://schema.org',
+          '@type': 'CreativeWork',
+          headline: 'MSAA + Overdraw Lab',
+          description:
+            'Landing route for the MSAA-overdraw interaction study covering compounded bandwidth and fragment pressure in Unity XR rendering.',
+          author: { '@type': 'Person', name: 'James De Raja' },
+          datePublished: '2025-01-01',
+          image: '/og-image.png',
+        }}
+      />
+      <Navigate to="/lab/msaa#msaa-overdraw" replace />
+    </>
+  );
 }

--- a/src/lab/pages/OverdrawLabPage.tsx
+++ b/src/lab/pages/OverdrawLabPage.tsx
@@ -1,9 +1,26 @@
 import { Link } from 'react-router-dom';
 import MetricsSummary from '../components/MetricsSummary';
+import { Seo } from '../../components/Seo';
 
 export default function OverdrawLabPage() {
   return (
     <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
+      <Seo
+        title="Overdraw Lab — James De Raja"
+        description="Controlled overdraw stress test quantifying fragment pressure, transparent pass escalation, and GPU bottleneck behavior in Unity XR."
+        url="https://james.alphaden.club/lab/overdraw"
+        keywords="overdraw lab, GPU fragment pressure, Unity XR, transparent pass"
+        type="article"
+        structuredData={{
+          '@context': 'https://schema.org',
+          '@type': 'CreativeWork',
+          headline: 'Overdraw Lab',
+          description: 'Controlled overdraw stress test quantifying fragment pressure, transparent pass escalation, and GPU bottleneck behavior in Unity XR.',
+          author: { '@type': 'Person', name: 'James De Raja' },
+          datePublished: '2025-01-01',
+          image: '/og-image.png',
+        }}
+      />
       <div style={{ marginBottom: '16px' }}>
         <Link to="/case-studies/xr-stress-lab">← Back to XR Stress Lab Case Study</Link>
       </div>

--- a/src/lab/pages/OverdrawStereoLabPage.tsx
+++ b/src/lab/pages/OverdrawStereoLabPage.tsx
@@ -1,10 +1,27 @@
 import { Link } from 'react-router-dom';
+import { Seo } from '../../components/Seo';
 
 export default function OverdrawStereoLabPage() {
   const budgetMs = 11.11;
 
   return (
     <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
+      <Seo
+        title="Stereo Overdraw Lab — James De Raja"
+        description="Stereo overdraw lab evaluating double-eye transparency cost, fragment amplification, and GPU budget pressure in XR rendering."
+        url="https://james.alphaden.club/lab/overdraw-stereo"
+        keywords="stereo overdraw, XR rendering, fragment cost, Unity performance"
+        type="article"
+        structuredData={{
+          '@context': 'https://schema.org',
+          '@type': 'CreativeWork',
+          headline: 'Stereo Overdraw Lab',
+          description: 'Stereo overdraw lab evaluating double-eye transparency cost, fragment amplification, and GPU budget pressure in XR rendering.',
+          author: { '@type': 'Person', name: 'James De Raja' },
+          datePublished: '2025-01-01',
+          image: '/og-image.png',
+        }}
+      />
       <div style={{ marginBottom: '16px' }}>
         <Link to="/?section=writing">← Back to Writing</Link>
       </div>

--- a/src/lab/pages/XRFrameTimingLabPage.tsx
+++ b/src/lab/pages/XRFrameTimingLabPage.tsx
@@ -2,10 +2,27 @@ import { Link } from 'react-router-dom';
 import ResultsTable from '../../components/ResultsTable';
 import SmartLink from '../../components/SmartLink';
 import { performanceResults } from '../../data/performanceResults';
+import { Seo } from '../../components/Seo';
 
 export default function XRFrameTimingLabPage() {
   return (
     <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">
+      <Seo
+        title="XR Frame Timing Lab — James De Raja"
+        description="Lab article on XR frame deadlines, compositor sync points, and practical profiling signals for reducing reprojection risk."
+        url="https://james.alphaden.club/lab/xr-frame-timing"
+        keywords="XR frame timing, compositor deadlines, reprojection, Unity XR"
+        type="article"
+        structuredData={{
+          '@context': 'https://schema.org',
+          '@type': 'CreativeWork',
+          headline: 'XR Frame Timing Lab',
+          description: 'Lab article on XR frame deadlines, compositor sync points, and practical profiling signals for reducing reprojection risk.',
+          author: { '@type': 'Person', name: 'James De Raja' },
+          datePublished: '2025-01-01',
+          image: '/og-image.png',
+        }}
+      />
       <div style={{ marginBottom: '16px' }}>
         <Link to="/?section=writing">← Back to Writing</Link>
       </div>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,16 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { HelmetProvider } from 'react-helmet-async';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App.tsx';
 import './index.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <HelmetProvider>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </HelmetProvider>
   </StrictMode>
 );

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -7,6 +7,7 @@ import WorkSection from '../sections/WorkSection';
 import WritingSection from '../sections/WritingSection';
 import XRLabSection from '../sections/XRLabSection';
 import ShippedTitlesSection from '../sections/ShippedTitlesSection';
+import { Seo } from '../components/Seo';
 
 export default function HomePage() {
   const location = useLocation();
@@ -27,6 +28,12 @@ export default function HomePage() {
 
   return (
     <div className="min-h-screen bg-site-pattern text-slate-900">
+      <Seo
+        title="James De Raja — Real-Time Performance Engineer"
+        description="Portfolio of James De Raja, senior real-time performance engineer specializing in Unity rendering, frame pacing discipline, and XR optimization."
+        url="https://james.alphaden.club/"
+        keywords="James De Raja, real-time performance engineer, Unity performance, XR optimization, frame pacing"
+      />
       <main>
         <HeroSection />
         <WorkSection />


### PR DESCRIPTION
### Motivation

- Improve SEO, social sharing metadata, and structured data across the site for case studies and lab pages.
- Include multiple resume variants and automate PDF generation from markdown to publish downloadable resumes.
- Add small accessibility improvements to visual components and ensure meta consistency site-wide.

### Description

- Introduces a reusable `Seo` component (`src/components/Seo.tsx`) backed by `react-helmet-async` and wires it into `main.tsx` with `HelmetProvider` and many pages (home, case studies, lab pages) to emit meta tags and JSON-LD structured data.  Adds `react-helmet-async` to `package.json` and the lockfile; related dependency entries were added to `package-lock.json`.
- Updates `index.html` metadata (canonical, robots, author, keywords, OG/twitter tags) and adds more consistent site metadata for sharing.
- Adds resume source markdown files under `public/resume/src/`, a PDF generation script `scripts/generate_resumes.py` (ReportLab-based), and generated PDFs under `public/resume/` for multiple resume variants.
- Expands `public/sitemap.xml` with case-study & lab routes and updates site entries.
- Accessibility and content tweaks: improved image `alt` text in `EvidenceCard.tsx` and `IconContainer.tsx`, added `aria-label` to the results table and `role`/`aria-label` to `MiniBars`, and minor markup/props cleanup in several pages.

### Testing

- Performed a local production build via `npm run build` (Vite) to verify the app compiles and server bundle is produced, which completed successfully. 
- No unit/integration tests were added or modified in this change set. 
- The resume generator requires `reportlab` (native Python dependency) and is included as a script but not executed in CI as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7c74ef98c832499ebf64f8fc4a397)