### PR TITLE
Add titled resume viewer page for PDF tab

### DIFF
--- a/public/resume/viewer.html
+++ b/public/resume/viewer.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Resume Viewer</title>
+    <style>
+      html,
+      body {
+        height: 100%;
+        margin: 0;
+      }
+
+      body {
+        font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+      }
+
+      iframe {
+        width: 100%;
+        height: 100%;
+        border: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <iframe id="resumeFrame" title="Resume PDF"></iframe>
+    <script>
+      const allowedFiles = new Set([
+        'JamesDeRaja_Resume.pdf',
+        'JamesDeRaja_Resume_Performance-Systems.pdf',
+        'JamesDeRaja_Resume_Unity-Rendering-Performance.pdf',
+        'JamesDeRaja_Resume_XR-Performance-Engineer.pdf'
+      ]);
+
+      const params = new URLSearchParams(window.location.search);
+      const file = params.get('file') || 'JamesDeRaja_Resume.pdf';
+      const selectedFile = allowedFiles.has(file) ? file : 'JamesDeRaja_Resume.pdf';
+
+      const resumeName = selectedFile.replace(/\.pdf$/i, '');
+      document.title = resumeName;
+
+      const frame = document.getElementById('resumeFrame');
+      frame.src = `/${'resume'}/${encodeURIComponent(selectedFile)}`;
+      frame.setAttribute('title', `${resumeName} PDF`);
+    </script>
+  </body>
+</html>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -24,7 +24,7 @@ export default function Navbar() {
           ))}
         </div>
         <SmartLink
-          href="/resume/JamesDeRaja_Resume.pdf"
+          href="/resume/viewer.html?file=JamesDeRaja_Resume.pdf"
           className="rounded-xl border border-cyan-700 bg-cyan-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-cyan-700"
         >
           View Resume (PDF)


### PR DESCRIPTION
### Motivation
- The browser opened the resume PDF in a new tab but the tab title showed as untitled, so the viewer should set a meaningful tab title matching the resume filename.

### Description
- Updated the navbar resume link in `src/components/Navbar.tsx` to point to a viewer page at ` /resume/viewer.html?file=JamesDeRaja_Resume.pdf`.
- Added `public/resume/viewer.html` which reads the `file` query parameter, validates it against an allowlist of resume filenames, sets `document.title` to the resume name (stripping `.pdf`), and embeds the PDF in an iframe while setting the iframe `title`.
- This routes resume opens through a simple viewer page to ensure the browser tab has a readable title derived from the resume filename.

### Testing
- Ran `npm run build` which completed successfully. 
- Verified the new files were added and committed (`public/resume/viewer.html` and `src/components/Navbar.tsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a90bb8337c83249b4d191cc40522f5)