### PR TITLE
Use fixed resume PDF and custom resume page title from navbar button

### DIFF
--- a/public/resume/viewer.html
+++ b/public/resume/viewer.html
@@ -36,8 +36,9 @@
       const file = params.get('file') || 'JamesDeRaja_Resume.pdf';
       const selectedFile = allowedFiles.has(file) ? file : 'JamesDeRaja_Resume.pdf';
 
+      const customTitle = params.get('title');
       const resumeName = selectedFile.replace(/\.pdf$/i, '');
-      document.title = resumeName;
+      document.title = customTitle || resumeName;
 
       const frame = document.getElementById('resumeFrame');
       frame.src = `/${'resume'}/${encodeURIComponent(selectedFile)}`;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -24,7 +24,7 @@ export default function Navbar() {
           ))}
         </div>
         <SmartLink
-          href="/resume/viewer.html?file=JamesDeRaja_Resume.pdf"
+          href="/resume/viewer.html?file=JamesDeRaja_Resume.pdf&title=James_De_Raja_Unity_XR_Performance_Engineer_Resume"
           className="rounded-xl border border-cyan-700 bg-cyan-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-cyan-700"
         >
           View Resume (PDF)


### PR DESCRIPTION
### Motivation
- The top-right "View Resume (PDF)" button should open the existing fixed PDF instead of generating one and the resume viewer page should show a specific title when opened from the navbar.

### Description
- Updated the navbar button to open the viewer with an explicit `file` and `title` query parameter (`/resume/viewer.html?file=JamesDeRaja_Resume.pdf&title=James_De_Raja_Unity_XR_Performance_Engineer_Resume`) in `src/components/Navbar.tsx`.
- Updated `public/resume/viewer.html` to read an optional `title` query parameter and set `document.title` to that value, falling back to the filename-derived title when `title` is not provided.
- The viewer still validates `file` against `allowedFiles` and defaults to `JamesDeRaja_Resume.pdf` if an invalid value is passed.

### Testing
- Ran the production build with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a940912938832494ef333a6f571bd1)