### PR TITLE
Rebrand site identity as game developer & graphic designer

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,32 +5,32 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="theme-color" content="#030308" />
-    <title>James De Raja — Real-Time Performance Engineer (Unity/XR)</title>
+    <title>James De Raja — Game Developer & Graphic Designer | Unity, XR, Mobile Games</title>
     <meta
       name="description"
-      content="Senior real-time performance engineer specialising in Unity rendering, frame pacing discipline and XR performance research with profiler-backed measurements."
+      content="Game developer and graphic designer with 13+ years in Unity. Shipped mobile titles, XR/VR experiences, and performance-optimized real-time graphics."
     />
     <link rel="canonical" href="https://jamesderaja.com/" />
     <meta name="robots" content="index,follow" />
     <meta name="author" content="James De Raja" />
     <meta
       name="keywords"
-      content="James De Raja, real-time performance engineer, Unity performance, XR optimisation, frame pacing, rendering cost isolation, GPU/CPU bottleneck"
+      content="James De Raja, game developer, graphic designer, Unity game developer, XR developer, VR developer, mobile games, UI UX design, real-time graphics"
     />
-    <meta property="og:title" content="James De Raja — Real-Time Performance Engineer (Unity/XR)" />
+    <meta property="og:title" content="James De Raja — Game Developer & Graphic Designer" />
     <meta
       property="og:description"
-      content="Unity rendering, frame pacing, and XR performance research with profiler-backed measurements."
+      content="Game developer and graphic designer with 13+ years in Unity. Shipped mobile titles, XR/VR experiences, and real-time graphics."
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://jamesderaja.com/" />
     <meta property="og:image" content="/og-image.png" />
     <meta property="og:site_name" content="James De Raja Portfolio" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="James De Raja — Real-Time Performance Engineer (Unity/XR)" />
+    <meta name="twitter:title" content="James De Raja — Game Developer & Graphic Designer" />
     <meta
       name="twitter:description"
-      content="Unity rendering, frame pacing, and XR performance research with profiler-backed measurements."
+      content="Game developer and graphic designer with 13+ years in Unity. Shipped mobile titles, XR/VR experiences, and real-time graphics."
     />
     <meta name="twitter:image" content="/og-image.png" />
   </head>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -7,7 +7,7 @@ import SmartLink from './SmartLink';
 const navItems = [
   { label: 'Work', hash: 'work' },
   { label: 'XR Lab', hash: 'xr-lab' },
-  { label: 'Shipped', hash: 'shipped-titles' },
+  { label: 'Games', hash: 'shipped-titles' },
   { label: 'Writing', hash: 'writing' },
   { label: 'About', hash: 'about' },
   { label: 'Contact', hash: 'contact' },

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -26,10 +26,10 @@ export default function HomePage() {
   return (
     <div className="relative min-h-screen bg-void-950 text-slate-200">
       <Seo
-        title="James De Raja — XR Performance Engineer | Unity Rendering & Frame Pacing"
-        description="Senior XR Performance Engineer with 13+ years isolating GPU/CPU bottlenecks in Unity. Specialised in stereo rendering (72/90Hz), frame pacing, overdraw, MSAA bandwidth, and OpenXR. Open to remote and relocation."
+        title="James De Raja — Game Developer & Graphic Designer | Unity, XR, Mobile Games"
+        description="Game developer and graphic designer with 13+ years in Unity. Shipped mobile titles, XR/VR experiences, and performance-optimized real-time graphics. Strong visual design background with expertise in UI/UX, branding, and game art."
         url="https://jamesderaja.com/"
-        keywords="XR performance engineer, Unity XR optimization, OpenXR performance, Meta Quest performance, stereo rendering optimization, GPU bottleneck analysis, frame pacing Unity, real-time rendering engineer, Unity 6 URP, XR frame timing, James De Raja"
+        keywords="game developer, graphic designer, Unity game developer, XR game development, mobile game developer, VR developer, game designer, UI UX design, real-time graphics, shipped games, James De Raja"
       />
 
       {/* Particle background */}

--- a/src/sections/AboutSection.tsx
+++ b/src/sections/AboutSection.tsx
@@ -3,31 +3,31 @@ import SectionHeading from '../components/SectionHeading';
 import AnimatedSection from '../components/AnimatedSection';
 
 const strengths = [
-  'XR stereo frame timing (72 / 90 Hz) and compositor deadline discipline',
-  'GPU/CPU bottleneck isolation — tile-based mobile GPU & PC rasterization pipeline',
-  'Overdraw, fragment pressure & MSAA bandwidth cost quantification',
-  'Draw call / SetPass reduction via GPU Instancing and state batching',
-  'Skinned mesh cost optimization and LOD-aware spawning',
-  'Deterministic pooling systems, zero-runtime-allocation update loops',
-  'Enterprise API integration & distributed systems (Zoho — scalable to enterprise XR backends)',
+  'Full-cycle game development — concept, prototype, art, ship, and post-launch optimization',
+  'XR / VR / MR game experiences with 72–90 Hz stereo rendering',
+  'Graphic design & UI/UX — game interfaces, branding, marketing assets',
+  'GPU/CPU performance profiling & frame budget optimization',
+  'Real-time visual effects, shaders, and rendering pipeline customization',
+  'Mobile game optimization — iOS & Android shipping experience',
+  'Enterprise systems integration (Zoho Corporation — 7+ years)',
 ];
 
 const toolCategories = [
   {
-    label: 'Profiling & Debugging',
-    tools: ['Unity Profiler', 'Frame Debugger', 'RenderDoc', 'OVR Metrics Tool', 'Xcode Instruments', 'Android Profiler'],
+    label: 'Game Engines & Languages',
+    tools: ['Unity 6', 'URP', 'Built-in Render Pipeline', 'OpenXR', 'C#', 'ShaderLab / HLSL'],
   },
   {
-    label: 'Engines & Pipelines',
-    tools: ['Unity 6', 'URP', 'Built-in Render Pipeline', 'OpenXR', 'C#'],
+    label: 'Design & Creative',
+    tools: ['Photoshop', 'Figma', 'Illustrator', 'After Effects', 'UI/UX Design', 'Visual Prototyping'],
   },
   {
-    label: 'XR & Platforms',
-    tools: ['Meta Quest (Android/OpenXR)', 'PCVR', 'iOS', 'Android', 'XR Interaction Toolkit'],
+    label: 'Platforms',
+    tools: ['Meta Quest (VR/MR)', 'PCVR', 'iOS', 'Android', 'WebGL'],
   },
   {
-    label: 'Systems & Dev',
-    tools: ['Git', 'REST APIs', 'Distributed Systems', 'CI/CD'],
+    label: 'Profiling & Tools',
+    tools: ['Unity Profiler', 'Frame Debugger', 'RenderDoc', 'Git', 'CI/CD'],
   },
 ];
 
@@ -41,7 +41,7 @@ export default function AboutSection() {
 
       <SectionHeading
         eyebrow="About"
-        title="Deterministic performance engineering for XR systems"
+        title="Game developer, graphic designer, performance nerd"
       />
 
       {/* Career narrative */}
@@ -59,7 +59,7 @@ export default function AboutSection() {
             </div>
             <div className="text-center sm:text-left">
               <p className="text-sm font-semibold text-white">James De Raja</p>
-              <p className="mt-0.5 text-xs text-slate-400">Senior Performance Engineer</p>
+              <p className="mt-0.5 text-xs text-slate-400">Game Developer &amp; Graphic Designer</p>
               <p className="mt-0.5 text-xs text-slate-500">Chennai &bull; Open to relocation</p>
               <span className="mt-2 inline-flex items-center gap-1.5 rounded-full border border-emerald-500/20 bg-emerald-500/5 px-2 py-0.5 text-xs font-medium text-emerald-400">
                 <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 animate-pulse" />
@@ -71,16 +71,16 @@ export default function AboutSection() {
           {/* Bio */}
           <div className="space-y-4 text-sm text-slate-300 leading-relaxed">
             <p>
-              I&apos;m a Senior Real-Time Performance Engineer with 13+ years optimizing Unity rendering pipelines, frame pacing, and CPU/GPU bottleneck behaviour under strict <span className="font-medium text-neon">11ms / 16ms frame budgets</span>. My focus is reproducible measurement: baseline vs stress deltas, bottleneck classification, and mitigation strategies teams can apply repeatedly.
+              I&apos;m a game developer and graphic designer with <span className="font-medium text-neon">13+ years</span> building games in Unity — from initial concept and visual design through to shipping and post-launch optimization. I love the intersection of art and engineering: making things that look great <em>and</em> run great.
             </p>
             <p>
-              Current work centres on the <span className="font-medium text-white">XR Performance Stress Lab</span> — a deterministic Unity 6 URP + OpenXR benchmark harness targeting Meta Quest / PCVR rendering constraints at <span className="font-medium text-neon">72Hz and 90Hz</span>.
+              My shipped titles span mobile games on iOS and Android, and my current focus is on <span className="font-medium text-white">XR / VR / MR experiences</span> — building immersive worlds that maintain buttery-smooth frame rates at <span className="font-medium text-neon">72Hz and 90Hz</span> on Meta Quest and PCVR.
             </p>
             <p>
-              In parallel, as a Senior Systems Engineer at <span className="font-medium text-white">Zoho Corporation</span> (2017–present), I architect enterprise API integrations and distributed systems across major SaaS platforms — directly transferable to enterprise XR backends bridging spatial front-ends with live data sources.
+              I also bring a strong graphic design background — crafting game UI/UX, brand identities, and marketing visuals. Design thinking informs every game I build, from menu flows to in-game HUDs to promotional art.
             </p>
             <p>
-              Experience spans shipping mobile titles for iOS and Android, XR rendering performance research, and engineering diagnostic tooling — research and production in equal measure.
+              In parallel, as a Senior Systems Engineer at <span className="font-medium text-white">Zoho Corporation</span> (2017–present), I architect enterprise integrations and distributed systems — experience that gives me a unique edge when building connected, data-driven game experiences.
             </p>
             <p className="text-slate-400">
               Open to remote roles and international relocation. <span className="font-medium text-white/80">B.E., Electrical &amp; Electronics — SSN College of Engineering, Chennai.</span>

--- a/src/sections/HeroSection.tsx
+++ b/src/sections/HeroSection.tsx
@@ -1,22 +1,24 @@
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { ArrowRight, Activity, Monitor, Clock } from 'lucide-react';
+import { ArrowRight, Gamepad2, Palette, Clock } from 'lucide-react';
 
 const metrics = [
-  { value: '+7.27ms', label: 'GPU cost isolated via overdraw stress', icon: Activity },
-  { value: '72/90Hz', label: 'XR stereo frame budget targets', icon: Monitor },
-  { value: '13+ yrs', label: 'Unity & real-time systems', icon: Clock },
+  { value: '10+', label: 'Shipped mobile & XR game titles', icon: Gamepad2 },
+  { value: '13+ yrs', label: 'Unity game development & real-time graphics', icon: Clock },
+  { value: '72/90Hz', label: 'XR performance targets hit consistently', icon: Palette },
 ];
 
 const chips = [
-  'XR Stereo Rendering',
-  'GPU/CPU Bottleneck Isolation',
-  'Frame Pacing',
-  'OpenXR',
-  'URP',
-  'Unity 6',
-  'RenderDoc',
-  'Frame Debugger',
+  'Unity Game Development',
+  'XR / VR / MR',
+  'Real-Time Graphics',
+  'UI/UX Design',
+  'Visual Effects',
+  'Performance Optimization',
+  'C# / Shaders',
+  'Mobile Games',
+  'Photoshop',
+  'Figma',
 ];
 
 const containerVariants = {
@@ -52,7 +54,7 @@ export default function HeroSection() {
           <motion.div variants={itemVariants}>
             <span className="inline-flex items-center gap-2 rounded-full border border-emerald-500/20 bg-emerald-500/5 px-4 py-1.5 text-xs font-medium text-emerald-400">
               <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 animate-pulse" />
-              Open to remote &amp; relocation — XR / VR / MR performance roles
+              Open to remote &amp; relocation — Game Development &amp; XR roles
             </span>
           </motion.div>
 
@@ -70,7 +72,7 @@ export default function HeroSection() {
             variants={itemVariants}
             className="mt-4 font-mono text-lg text-neon/80 sm:text-xl"
           >
-            Senior Real-Time Performance Engineer
+            Game Developer &amp; Graphic Designer
           </motion.p>
 
           {/* Subtitle */}
@@ -78,7 +80,7 @@ export default function HeroSection() {
             variants={itemVariants}
             className="mt-2 text-base text-slate-400"
           >
-            XR Rendering &bull; GPU/CPU Bottleneck Analysis &bull; Frame Pacing Discipline
+            Unity &bull; XR / VR / MR &bull; Mobile Games &bull; Real-Time Graphics &bull; Visual Design
           </motion.p>
 
           {/* Mission statement */}
@@ -87,9 +89,11 @@ export default function HeroSection() {
             className="mt-8 max-w-2xl"
           >
             <p className="text-lg text-slate-300 leading-relaxed">
-              I design deterministic frameworks to isolate rendering bottlenecks in real-time XR systems.
-              Every claim is backed by{' '}
-              <span className="text-neon font-medium">profiler-validated measurements</span>.
+              I build immersive games and craft compelling visuals — from concept art to shipped titles.
+              With 13+ years in Unity, I combine{' '}
+              <span className="text-neon font-medium">creative design instincts</span> with{' '}
+              <span className="text-neon font-medium">deep technical expertise</span> to deliver
+              polished, high-performance experiences across mobile, XR, and desktop.
             </p>
           </motion.div>
 
@@ -99,10 +103,10 @@ export default function HeroSection() {
             className="mt-6 space-y-2 text-sm text-slate-400"
           >
             {[
-              'XR rendering performance & stereo frame budget discipline',
-              'CPU/GPU bottleneck isolation via controlled A/B stress tests',
-              'Frame pacing stability — variance, spikes, compositor deadline adherence',
-              'Overdraw & MSAA bandwidth quantification with profiler evidence',
+              'End-to-end game development — design, prototype, build, ship, and optimize',
+              'XR / VR / MR experiences with buttery-smooth 72–90 Hz rendering',
+              'Graphic design & UI/UX — from game interfaces to brand identity',
+              'Performance engineering — profiling, GPU/CPU optimization, frame budget discipline',
             ].map((item) => (
               <li key={item} className="flex items-start gap-3">
                 <span className="mt-1.5 h-1 w-1 flex-shrink-0 rounded-full bg-neon" />
@@ -148,32 +152,32 @@ export default function HeroSection() {
             className="mt-10 flex flex-wrap gap-4"
           >
             <a
-              href="#contact"
+              href="#shipped-titles"
               className="btn-primary group inline-flex items-center gap-2 rounded-xl px-6 py-3 text-sm font-medium"
             >
-              Contact Me
+              View My Games
               <ArrowRight size={14} className="transition group-hover:translate-x-1" />
             </a>
             <a
-              href="#xr-lab"
-              className="btn-secondary rounded-xl px-6 py-3 text-sm font-medium"
-            >
-              View XR Lab
-            </a>
-            <Link
-              to="/case-studies/xr-stress-lab"
+              href="#work"
               className="btn-secondary rounded-xl px-6 py-3 text-sm font-medium"
             >
               Case Studies
-            </Link>
+            </a>
+            <a
+              href="#contact"
+              className="btn-secondary rounded-xl px-6 py-3 text-sm font-medium"
+            >
+              Get in Touch
+            </a>
           </motion.div>
 
-          {/* Validation footer */}
+          {/* Footer */}
           <motion.p
             variants={itemVariants}
             className="mt-8 font-mono text-xs text-slate-600"
           >
-            Validated via Unity Profiler &amp; Frame Debugger &bull; Unity 6 URP + OpenXR &bull; Chennai, India
+            Unity 6 &bull; C# &bull; URP + OpenXR &bull; Photoshop &bull; Figma &bull; Chennai, India
           </motion.p>
         </motion.div>
       </div>

--- a/src/sections/ShippedTitlesSection.tsx
+++ b/src/sections/ShippedTitlesSection.tsx
@@ -9,9 +9,9 @@ export default function ShippedTitlesSection() {
   return (
     <section id="shipped-titles" className="relative mx-auto max-w-7xl px-4 py-20 sm:px-6 lg:px-8">
       <SectionHeading
-        eyebrow="Production Evidence"
-        title="Shipped Titles — Runtime Performance Results"
-        subtitle="Published mobile titles where profiling-driven optimisation produced measurable frame-budget improvements. Games as engineering evidence, not portfolio decoration."
+        eyebrow="Shipped Games"
+        title="Games I've Built &amp; Published"
+        subtitle="Real titles on real app stores — designed, developed, and optimized from start to finish. Each one a complete journey from blank project to live players."
       />
       <div className="grid gap-6 md:grid-cols-3">
         {shippedTitles.map((title, i) => (


### PR DESCRIPTION
Update hero, about, shipped titles, navbar, and SEO meta to clearly communicate game development and graphic design as the primary identity, while keeping technical depth (XR, performance) as supporting expertise.

https://claude.ai/code/session_01Jv2wM9AKZ7NKKPrxJVW4Qc