### PR TITLE
Reduce visual flicker and stabilize motion rendering

### DIFF
--- a/src/components/AnimatedSection.tsx
+++ b/src/components/AnimatedSection.tsx
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion';
+import { motion, useReducedMotion } from 'framer-motion';
 import type { ReactNode } from 'react';
 
 type AnimatedSectionProps = {
@@ -8,12 +8,14 @@ type AnimatedSectionProps = {
 };
 
 export default function AnimatedSection({ children, className = '', delay = 0 }: AnimatedSectionProps) {
+  const prefersReducedMotion = useReducedMotion();
+
   return (
     <motion.div
-      initial={{ opacity: 0, y: 40 }}
+      initial={prefersReducedMotion ? false : { opacity: 0, y: 24 }}
       whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, margin: '-80px' }}
-      transition={{ duration: 0.7, delay, ease: [0.22, 1, 0.36, 1] }}
+      viewport={{ once: true, margin: '-60px 0px' }}
+      transition={{ duration: prefersReducedMotion ? 0.2 : 0.6, delay, ease: [0.22, 1, 0.36, 1] }}
       className={className}
     >
       {children}

--- a/src/components/ParticleField.tsx
+++ b/src/components/ParticleField.tsx
@@ -10,6 +10,10 @@ type Particle = {
   hue: number;
 };
 
+const MAX_DPR = 1.75;
+const CONNECTION_DISTANCE = 150;
+const CONNECTION_DISTANCE_SQ = CONNECTION_DISTANCE * CONNECTION_DISTANCE;
+
 export default function ParticleField() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const animationRef = useRef<number>(0);
@@ -20,106 +24,156 @@ export default function ParticleField() {
     const canvas = canvasRef.current;
     if (!canvas) return;
 
-    const ctx = canvas.getContext('2d');
+    const ctx = canvas.getContext('2d', { alpha: true });
     if (!ctx) return;
 
-    const resize = () => {
-      canvas.width = window.innerWidth;
-      canvas.height = window.innerHeight;
-    };
-    resize();
-    window.addEventListener('resize', resize);
+    let isDisposed = false;
+    let isTabVisible = document.visibilityState === 'visible';
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-    // Initialize particles
-    const count = Math.min(80, Math.floor(window.innerWidth / 20));
-    particlesRef.current = Array.from({ length: count }, () => ({
-      x: Math.random() * canvas.width,
-      y: Math.random() * canvas.height,
-      vx: (Math.random() - 0.5) * 0.4,
-      vy: (Math.random() - 0.5) * 0.4,
-      size: Math.random() * 2 + 0.5,
-      opacity: Math.random() * 0.5 + 0.1,
-      hue: Math.random() > 0.7 ? 270 : 185, // cyan or purple
-    }));
+    const getDpr = () => Math.min(window.devicePixelRatio || 1, MAX_DPR);
+
+    const resize = () => {
+      const dpr = getDpr();
+      const width = Math.floor(window.innerWidth);
+      const height = Math.floor(window.innerHeight);
+
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+      canvas.width = Math.floor(width * dpr);
+      canvas.height = Math.floor(height * dpr);
+
+      // Reset transform each resize so drawing coordinates stay in CSS pixels.
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    };
+
+    const createParticles = () => {
+      const count = Math.min(70, Math.floor(window.innerWidth / 24));
+      particlesRef.current = Array.from({ length: count }, () => ({
+        x: Math.random() * window.innerWidth,
+        y: Math.random() * window.innerHeight,
+        vx: (Math.random() - 0.5) * 0.3,
+        vy: (Math.random() - 0.5) * 0.3,
+        size: Math.random() * 2 + 0.5,
+        opacity: Math.random() * 0.45 + 0.12,
+        hue: Math.random() > 0.72 ? 270 : 185,
+      }));
+    };
+
+    let resizeRaf = 0;
+    const handleResize = () => {
+      cancelAnimationFrame(resizeRaf);
+      resizeRaf = requestAnimationFrame(() => {
+        resize();
+        createParticles();
+      });
+    };
+
+    resize();
+    createParticles();
 
     const handleMouse = (e: MouseEvent) => {
       mouseRef.current = { x: e.clientX, y: e.clientY };
     };
-    window.addEventListener('mousemove', handleMouse);
 
-    const animate = () => {
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
+    const handleVisibility = () => {
+      isTabVisible = document.visibilityState === 'visible';
+      if (isTabVisible && !animationRef.current) {
+        animationRef.current = requestAnimationFrame(animate);
+      }
+    };
+
+    let previousTime = performance.now();
+
+    const animate = (time: number) => {
+      animationRef.current = 0;
+      if (isDisposed || !isTabVisible) return;
+
+      const dt = Math.min((time - previousTime) / 16.6667, 1.6);
+      previousTime = time;
+
+      const width = window.innerWidth;
+      const height = window.innerHeight;
+
+      ctx.clearRect(0, 0, width, height);
       const particles = particlesRef.current;
       const mouse = mouseRef.current;
 
       for (let i = 0; i < particles.length; i++) {
         const p = particles[i];
 
-        // Update position
-        p.x += p.vx;
-        p.y += p.vy;
+        p.x += p.vx * dt;
+        p.y += p.vy * dt;
 
-        // Wrap around
-        if (p.x < 0) p.x = canvas.width;
-        if (p.x > canvas.width) p.x = 0;
-        if (p.y < 0) p.y = canvas.height;
-        if (p.y > canvas.height) p.y = 0;
+        if (p.x < 0) p.x = width;
+        if (p.x > width) p.x = 0;
+        if (p.y < 0) p.y = height;
+        if (p.y > height) p.y = 0;
 
-        // Draw particle
         ctx.beginPath();
         ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
         ctx.fillStyle = `hsla(${p.hue}, 100%, 70%, ${p.opacity})`;
         ctx.fill();
 
-        // Draw connections to nearby particles
         for (let j = i + 1; j < particles.length; j++) {
           const p2 = particles[j];
           const dx = p.x - p2.x;
           const dy = p.y - p2.y;
-          const dist = Math.sqrt(dx * dx + dy * dy);
+          const distSq = dx * dx + dy * dy;
 
-          if (dist < 150) {
+          if (distSq < CONNECTION_DISTANCE_SQ) {
+            const dist = Math.sqrt(distSq);
+            const alpha = 0.055 * (1 - dist / CONNECTION_DISTANCE);
             ctx.beginPath();
             ctx.moveTo(p.x, p.y);
             ctx.lineTo(p2.x, p2.y);
-            ctx.strokeStyle = `hsla(185, 100%, 70%, ${0.06 * (1 - dist / 150)})`;
+            ctx.strokeStyle = `hsla(185, 100%, 70%, ${alpha})`;
             ctx.lineWidth = 0.5;
             ctx.stroke();
           }
         }
 
-        // Mouse interaction - gentle repulsion
         const mdx = p.x - mouse.x;
         const mdy = p.y - mouse.y;
-        const mDist = Math.sqrt(mdx * mdx + mdy * mdy);
-        if (mDist < 200 && mDist > 0) {
-          const force = (200 - mDist) / 200 * 0.02;
-          p.vx += (mdx / mDist) * force;
-          p.vy += (mdy / mDist) * force;
+        const mDistSq = mdx * mdx + mdy * mdy;
+
+        if (mDistSq < 40_000 && mDistSq > 0) {
+          const mDist = Math.sqrt(mDistSq);
+          const force = ((200 - mDist) / 200) * 0.018;
+          p.vx += (mdx / mDist) * force * dt;
+          p.vy += (mdy / mDist) * force * dt;
         }
 
-        // Damping
-        p.vx *= 0.999;
-        p.vy *= 0.999;
+        const damping = reduceMotion ? 0.994 : 0.9985;
+        p.vx *= damping;
+        p.vy *= damping;
       }
 
       animationRef.current = requestAnimationFrame(animate);
     };
 
-    animate();
+    window.addEventListener('resize', handleResize, { passive: true });
+    window.addEventListener('mousemove', handleMouse, { passive: true });
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    animationRef.current = requestAnimationFrame(animate);
 
     return () => {
-      window.removeEventListener('resize', resize);
+      isDisposed = true;
+      window.removeEventListener('resize', handleResize);
       window.removeEventListener('mousemove', handleMouse);
+      document.removeEventListener('visibilitychange', handleVisibility);
       cancelAnimationFrame(animationRef.current);
+      cancelAnimationFrame(resizeRaf);
+      animationRef.current = 0;
     };
   }, []);
 
   return (
     <canvas
       ref={canvasRef}
-      className="pointer-events-none fixed inset-0 z-0"
-      style={{ opacity: 0.6 }}
+      className="pointer-events-none fixed inset-0 z-0 particle-canvas"
+      style={{ opacity: 0.55 }}
       aria-hidden="true"
     />
   );

--- a/src/index.css
+++ b/src/index.css
@@ -202,3 +202,26 @@ body {
   color: #00f0ff;
   transform: translateY(-1px);
 }
+
+/* ── Flicker mitigation + motion safety ── */
+.particle-canvas {
+  transform: translateZ(0);
+  backface-visibility: hidden;
+  will-change: transform, opacity;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  .particle-canvas {
+    display: none;
+  }
+}


### PR DESCRIPTION
### Motivation
- Reduce intermittent canvas flicker and perceived jitter from the decorative particle background during resizes, tab switches, and performance dips. 
- Respect motion-reduction preferences so entrance animations don't cause distracting pops for motion-sensitive users.

### Description
- Reworked the particle renderer in `src/components/ParticleField.tsx` to use DPR-aware sizing with a capped `MAX_DPR`, set canvas CSS size separately from backing pixel size, and call `ctx.setTransform` so drawing uses CSS pixels. 
- Debounced resize handling with RAF and re-created the particle set on resize, added visibility monitoring to pause/resume the RAF loop, normalized updates by frame delta (`dt`), and tuned particle counts, connection distance, damping and forces for steadier visuals. 
- Switched the canvas context to `getContext('2d', { alpha: true })`, added a `particle-canvas` class and slightly reduced opacity to reduce harsh repaints. 
- Updated `src/components/AnimatedSection.tsx` to use `useReducedMotion`, softened `initial`/`transition` values and adjusted viewport margin to reduce pop/flicker on section entrance. 
- Added CSS in `src/index.css` providing GPU compositing hints (`transform: translateZ(0); backface-visibility: hidden; will-change: ...`) and a `prefers-reduced-motion` media rule that disables decorative animations and smooth-scroll when requested. 

### Testing
- Ran a production build with `npm run build` (Vite) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca098a297c83249e07a7f71d1ed2d0)