### PR TITLE
Refine portfolio visual system for recruiter readability and polish

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -41,7 +41,7 @@ export default function Navbar() {
     <header
       className={`sticky top-0 z-50 transition-all duration-500 ${
         scrolled
-          ? 'border-b border-neon/10 bg-void-950/80 backdrop-blur-xl'
+          ? 'border-b border-blue-200/10 bg-void-950/80 backdrop-blur-xl'
           : 'bg-transparent'
       }`}
     >
@@ -51,10 +51,10 @@ export default function Navbar() {
       >
         {/* Logo */}
         <Link to="/" className="group flex items-center gap-2">
-          <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-neon/20 bg-neon/5">
-            <span className="font-mono text-sm font-bold text-neon">JD</span>
+          <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-blue-200/20 bg-blue-200/10">
+            <span className="font-mono text-sm font-bold text-blue-100">JD</span>
           </div>
-          <span className="text-sm font-semibold tracking-tight text-white/90 transition group-hover:text-neon">
+          <span className="text-sm font-semibold tracking-tight text-white/90 transition group-hover:text-blue-100">
             James De Raja
           </span>
         </Link>
@@ -66,7 +66,7 @@ export default function Navbar() {
               key={item.label}
               type="button"
               onClick={() => handleNavClick(item.hash)}
-              className="rounded-lg px-3 py-2 text-sm text-slate-400 transition-colors hover:bg-white/5 hover:text-neon"
+              className="rounded-lg px-3 py-2 text-sm text-slate-300 transition-colors hover:bg-white/5 hover:text-blue-100"
             >
               {item.label}
             </button>
@@ -84,7 +84,7 @@ export default function Navbar() {
           <a
             href="/resume/JamesDeRaja_Resume.pdf"
             download
-            className="rounded-lg border border-white/10 p-2 text-slate-400 transition hover:border-neon/30 hover:text-neon"
+            className="rounded-lg border border-white/10 p-2 text-slate-300 transition hover:border-blue-200/40 hover:text-blue-100"
             aria-label="Download resume PDF"
           >
             <Download size={16} />
@@ -92,7 +92,7 @@ export default function Navbar() {
           <button
             type="button"
             onClick={() => setMobileOpen(!mobileOpen)}
-            className="rounded-lg p-2 text-slate-400 hover:bg-white/5 hover:text-neon md:hidden"
+            className="rounded-lg p-2 text-slate-300 hover:bg-white/5 hover:text-blue-100 md:hidden"
             aria-label={mobileOpen ? 'Close menu' : 'Open menu'}
             aria-expanded={mobileOpen}
           >
@@ -116,7 +116,7 @@ export default function Navbar() {
                   key={item.label}
                   type="button"
                   onClick={() => handleNavClick(item.hash)}
-                  className="block w-full rounded-lg px-3 py-3 text-left text-sm text-slate-300 transition hover:bg-white/5 hover:text-neon"
+                  className="block w-full rounded-lg px-3 py-3 text-left text-sm text-slate-200 transition hover:bg-white/5 hover:text-blue-100"
                 >
                   {item.label}
                 </button>

--- a/src/components/SectionHeading.tsx
+++ b/src/components/SectionHeading.tsx
@@ -10,7 +10,7 @@ export default function SectionHeading({ eyebrow, title, subtitle }: SectionHead
   return (
     <AnimatedSection className="mb-12">
       {eyebrow && (
-        <p className="mb-3 font-mono text-xs font-semibold uppercase tracking-[0.2em] text-neon">
+        <p className="mb-3 font-mono text-xs font-semibold uppercase tracking-[0.2em] text-blue-200">
           {'// '}{eyebrow}
         </p>
       )}
@@ -18,7 +18,7 @@ export default function SectionHeading({ eyebrow, title, subtitle }: SectionHead
         {title}
       </h2>
       {subtitle && (
-        <p className="mt-4 max-w-3xl text-base text-slate-400 leading-relaxed">
+        <p className="mt-4 max-w-3xl text-base leading-relaxed text-slate-300">
           {subtitle}
         </p>
       )}

--- a/src/components/WorkCard.tsx
+++ b/src/components/WorkCard.tsx
@@ -11,8 +11,8 @@ type WorkCardProps = {
 export default function WorkCard({ project }: WorkCardProps) {
   return (
     <motion.article
-      whileHover={{ y: -4 }}
-      transition={{ duration: 0.3 }}
+      whileHover={{ y: -6, scale: 1.01 }}
+      transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
       className={`glass-card glass-card-hover rounded-2xl p-6 transition-all duration-300 ${
         project.featured ? 'gradient-border' : ''
       }`}
@@ -26,7 +26,7 @@ export default function WorkCard({ project }: WorkCardProps) {
           </span>
         )}
       </div>
-      <p className="mt-2 text-sm text-slate-400 leading-relaxed">{project.summary}</p>
+      <p className="mt-2 text-sm leading-relaxed text-slate-300">{project.summary}</p>
 
       {/* What I did */}
       <div className="mt-5">

--- a/src/index.css
+++ b/src/index.css
@@ -5,8 +5,8 @@
 @tailwind utilities;
 
 :root {
-  color: #e2e8f0;
-  background-color: #030308;
+  color: #d7dfec;
+  background-color: #040713;
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, sans-serif;
 }
 
@@ -17,7 +17,10 @@ html {
 body {
   margin: 0;
   min-width: 320px;
-  background-color: #030308;
+  background:
+    radial-gradient(circle at 10% 10%, rgba(118, 152, 255, 0.12), transparent 35%),
+    radial-gradient(circle at 90% 0%, rgba(176, 120, 255, 0.1), transparent 40%),
+    #040713;
   overflow-x: hidden;
 }
 
@@ -69,15 +72,22 @@ body {
 
 /* ── Glassmorphism card ── */
 .glass-card {
-  background: rgba(10, 10, 26, 0.6);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
-  border: 1px solid rgba(0, 240, 255, 0.08);
+  background:
+    linear-gradient(140deg, rgba(19, 27, 50, 0.88), rgba(10, 14, 30, 0.86)),
+    rgba(11, 17, 36, 0.75);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  border: 1px solid rgba(148, 174, 255, 0.2);
+  box-shadow:
+    0 18px 40px rgba(2, 5, 17, 0.45),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
 .glass-card-hover:hover {
-  border-color: rgba(0, 240, 255, 0.2);
-  box-shadow: 0 0 30px rgba(0, 240, 255, 0.08);
+  border-color: rgba(172, 192, 255, 0.35);
+  box-shadow:
+    0 24px 52px rgba(2, 5, 17, 0.55),
+    0 0 0 1px rgba(172, 192, 255, 0.1);
 }
 
 /* ── Gradient border effect ── */
@@ -179,28 +189,35 @@ body {
 
 /* ── Button styles ── */
 .btn-primary {
-  background: linear-gradient(135deg, rgba(0, 240, 255, 0.15), rgba(0, 240, 255, 0.05));
-  border: 1px solid rgba(0, 240, 255, 0.3);
-  color: #00f0ff;
+  background: linear-gradient(135deg, rgba(153, 177, 255, 0.25), rgba(130, 108, 255, 0.2));
+  border: 1px solid rgba(178, 197, 255, 0.4);
+  color: #ecf3ff;
   transition: all 0.3s ease;
 }
 .btn-primary:hover {
-  background: linear-gradient(135deg, rgba(0, 240, 255, 0.25), rgba(0, 240, 255, 0.1));
-  border-color: rgba(0, 240, 255, 0.5);
-  box-shadow: 0 0 25px rgba(0, 240, 255, 0.15);
+  background: linear-gradient(135deg, rgba(178, 198, 255, 0.38), rgba(154, 131, 255, 0.28));
+  border-color: rgba(201, 213, 255, 0.6);
+  box-shadow: 0 12px 28px rgba(84, 98, 190, 0.35);
   transform: translateY(-1px);
 }
 
 .btn-secondary {
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  color: #94a3b8;
+  background: rgba(171, 189, 255, 0.08);
+  border: 1px solid rgba(196, 210, 255, 0.18);
+  color: #c9d3ea;
   transition: all 0.3s ease;
 }
 .btn-secondary:hover {
-  border-color: rgba(0, 240, 255, 0.3);
-  color: #00f0ff;
+  border-color: rgba(200, 215, 255, 0.45);
+  color: #f1f5ff;
+  background: rgba(188, 202, 255, 0.12);
   transform: translateY(-1px);
+}
+
+.soft-panel {
+  background: linear-gradient(160deg, rgba(245, 248, 255, 0.07), rgba(177, 195, 255, 0.04));
+  border: 1px solid rgba(205, 217, 255, 0.18);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
 }
 
 /* ── Flicker mitigation + motion safety ── */

--- a/src/sections/HeroSection.tsx
+++ b/src/sections/HeroSection.tsx
@@ -20,25 +20,25 @@ function HeroStats() {
   const fps = useCountUp({ end: 60, duration: 1.0, delay: 0.2 });
 
   return (
-    <div className="mt-12 grid grid-cols-3 gap-8">
-      <div>
-        <p ref={years.ref as React.RefObject<HTMLParagraphElement>} className="font-mono text-4xl font-bold text-neon text-glow-cyan sm:text-6xl">
+    <div className="mt-10 grid grid-cols-1 gap-4 sm:mt-12 sm:grid-cols-3 sm:gap-8">
+      <div className="soft-panel rounded-2xl p-4 sm:border-0 sm:bg-transparent sm:p-0 sm:shadow-none">
+        <p ref={years.ref as React.RefObject<HTMLParagraphElement>} className="font-mono text-4xl font-bold text-neon sm:text-6xl">
           {years.count}+
         </p>
-        <p className="mt-2 text-sm text-slate-400">years in Unity</p>
+        <p className="mt-2 text-sm text-slate-300">years in Unity</p>
       </div>
-      <div>
+      <div className="soft-panel rounded-2xl p-4 sm:border-0 sm:bg-transparent sm:p-0 sm:shadow-none">
         <p ref={titles.ref as React.RefObject<HTMLParagraphElement>} className="font-mono text-4xl font-bold text-white sm:text-6xl">
           {titles.count}+
         </p>
-        <p className="mt-2 text-sm text-slate-400">shipped titles</p>
-        <p className="mt-0.5 text-xs text-slate-500">incl. multi-publisher PPP programs</p>
+        <p className="mt-2 text-sm text-slate-300">shipped titles</p>
+        <p className="mt-0.5 text-xs text-slate-400">incl. multi-publisher PPP programs</p>
       </div>
-      <div>
+      <div className="soft-panel rounded-2xl p-4 sm:border-0 sm:bg-transparent sm:p-0 sm:shadow-none">
         <p ref={fps.ref as React.RefObject<HTMLParagraphElement>} className="font-mono text-4xl font-bold text-electric sm:text-6xl">
           {fps.count}<span className="text-2xl sm:text-4xl">fps</span>
         </p>
-        <p className="mt-2 text-sm text-slate-400">locked on low-end devices</p>
+        <p className="mt-2 text-sm text-slate-300">locked on low-end devices</p>
       </div>
     </div>
   );
@@ -63,8 +63,8 @@ export default function HeroSection() {
         >
           {/* Status badge */}
           <motion.div variants={itemVariants}>
-            <span className="inline-flex items-center gap-2 rounded-full border border-emerald-500/20 bg-emerald-500/5 px-4 py-1.5 text-xs font-medium text-emerald-400">
-              <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 animate-pulse" />
+            <span className="inline-flex items-center gap-2 rounded-full border border-emerald-300/30 bg-emerald-300/10 px-4 py-1.5 text-xs font-medium text-emerald-200">
+              <span className="h-1.5 w-1.5 rounded-full bg-emerald-300 animate-pulse" />
               Open to remote &amp; relocation — rendering, XR performance, engine optimization
             </span>
           </motion.div>
@@ -81,13 +81,13 @@ export default function HeroSection() {
           {/* Specialist title */}
           <motion.p
             variants={itemVariants}
-            className="mt-4 text-xl font-semibold text-neon/90 sm:text-2xl lg:text-3xl"
+            className="mt-4 text-xl font-semibold text-blue-100 sm:text-2xl lg:text-3xl"
           >
             Real-Time Performance Engineer
           </motion.p>
           <motion.p
             variants={itemVariants}
-            className="mt-1 text-base text-slate-400 sm:text-lg"
+            className="mt-1 text-base text-slate-300 sm:text-lg"
           >
             Unity Rendering &bull; Frame Stability &bull; XR / Mobile / Shipped Titles
           </motion.p>
@@ -95,7 +95,7 @@ export default function HeroSection() {
           {/* Value prop */}
           <motion.p
             variants={itemVariants}
-            className="mt-8 max-w-2xl text-lg text-slate-200 leading-relaxed sm:text-xl"
+            className="mt-8 max-w-2xl text-lg leading-relaxed text-slate-100 sm:text-xl"
           >
             Delivered 100+ rapid prototypes and production titles for global publishers across 13+ years in Unity.
             I find the bottleneck, prove it with a profiler, fix it, and{' '}
@@ -105,7 +105,7 @@ export default function HeroSection() {
           {/* Impact proof */}
           <motion.div
             variants={itemVariants}
-            className="mt-4 flex flex-wrap gap-x-6 gap-y-1 text-sm text-slate-400"
+            className="mt-4 flex flex-wrap gap-x-6 gap-y-1 text-sm text-slate-300"
           >
             <span><span className="font-semibold text-emerald-400">45 → 60+ FPS</span> recovered in shipped combat scenes</span>
             <span><span className="font-semibold text-emerald-400">+7.27ms</span> GPU cost isolated in XR stereo overdraw</span>

--- a/src/sections/ProblemsSolvedSection.tsx
+++ b/src/sections/ProblemsSolvedSection.tsx
@@ -34,7 +34,7 @@ export default function ProblemsSolvedSection() {
   return (
     <section id="problems-solved" className="relative py-20">
       {/* Distinct background zone — separates this from uniform sections */}
-      <div className="pointer-events-none absolute inset-0 -z-10 bg-white/[0.015]" />
+      <div className="pointer-events-none absolute inset-0 -z-10 bg-white/[0.02]" />
       <div className="pointer-events-none absolute inset-0 -z-10">
         <div className="absolute left-0 top-1/2 h-[400px] w-[400px] -translate-y-1/2 rounded-full bg-electric/3 blur-[150px]" />
         <div className="absolute right-0 bottom-0 h-[300px] w-[300px] rounded-full bg-red-500/3 blur-[120px]" />
@@ -51,14 +51,14 @@ export default function ProblemsSolvedSection() {
         {problems.map((p, i) => (
           <AnimatedSection key={p.title} delay={i * 0.1}>
             <motion.div
-              whileHover={{ y: -2 }}
+              whileHover={{ y: -4, scale: 1.005 }}
               className="glass-card glass-card-hover rounded-2xl overflow-hidden transition-all duration-300"
             >
               {/* Header with prominent result metric */}
               <div className="flex flex-col gap-4 border-b border-white/5 p-6 sm:flex-row sm:items-center sm:justify-between sm:p-8">
                 <h3 className="text-lg font-semibold text-white">{p.title}</h3>
                 <div className="flex-shrink-0 rounded-xl border border-emerald-500/20 bg-emerald-500/5 px-5 py-2.5">
-                  <p className="font-mono text-xl font-bold text-emerald-400 sm:text-2xl">{p.resultHighlight}</p>
+                  <p className="font-mono text-xl font-bold text-emerald-300 sm:text-2xl">{p.resultHighlight}</p>
                 </div>
               </div>
 
@@ -70,13 +70,13 @@ export default function ProblemsSolvedSection() {
                     <AlertTriangle size={12} />
                     Problem
                   </div>
-                  <p className="mt-3 text-sm text-slate-300 leading-relaxed">{p.problem}</p>
+                  <p className="mt-3 text-sm leading-relaxed text-slate-200">{p.problem}</p>
 
                   <div className="mt-5 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-amber-400">
                     <Search size={12} />
                     Diagnosis
                   </div>
-                  <p className="mt-3 text-sm text-slate-300 leading-relaxed">{p.diagnosis}</p>
+                  <p className="mt-3 text-sm leading-relaxed text-slate-200">{p.diagnosis}</p>
                 </div>
 
                 {/* Right: Fix + Result */}
@@ -85,7 +85,7 @@ export default function ProblemsSolvedSection() {
                     <Wrench size={12} />
                     Fix
                   </div>
-                  <p className="mt-3 text-sm text-slate-300 leading-relaxed">{p.fix}</p>
+                  <p className="mt-3 text-sm leading-relaxed text-slate-200">{p.fix}</p>
 
                   <div className="mt-5 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-emerald-400">
                     <TrendingUp size={12} />


### PR DESCRIPTION
### Motivation
- Make the site less harsh and more recruiter-friendly by shifting the palette away from bright neon-on-black toward a softer indigo/glass aesthetic. 
- Improve scanning and legibility for key recruiter-facing content (hero, metrics, case-study summaries) across small and large screens. 
- Soften motion and hover behaviour to feel polished while keeping accessibility for users who prefer reduced motion. 

### Description
- Adjusted global colors, page background, card surfaces and button treatments in `src/index.css` to an indigo/soft-glass theme and added a reusable `.soft-panel` utility for lightweight panels. 
- Reworked hero metric block to stack on small screens and added soft panel styling and higher-contrast text in `src/sections/HeroSection.tsx` for improved mobile readability. 
- Tuned card interactions and copy contrast for case-study and problems-solved cards by changing hover transforms, scale/elevation and body text color in `src/components/WorkCard.tsx` and `src/sections/ProblemsSolvedSection.tsx`. 
- Harmonized navigation and section-heading color hierarchy to blue-toned accents and slightly brighter copy for easier scanning, with updates in `src/components/Navbar.tsx` and `src/components/SectionHeading.tsx`. 

### Testing
- Built a production bundle with `npm run build` and the build completed successfully. 
- Verified the working tree was clean after staging the visual changes and committing them.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb60ee67c08324b7b183a4e49c927a)