### PR TITLE
Add proof-first bento resume scaffold and update homepage for recruiter-first UX

### DIFF
--- a/mockups/minimal-professional.svg
+++ b/mockups/minimal-professional.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="820" viewBox="0 0 1200 820">
+  <rect width="1200" height="820" fill="#F8FAFC"/>
+  <rect x="40" y="40" width="740" height="180" rx="24" fill="#0F172A"/>
+  <rect x="800" y="40" width="360" height="180" rx="24" fill="#FFFFFF" stroke="#CBD5E1"/>
+  <text x="76" y="140" font-family="Georgia, serif" font-size="44" fill="#FFFFFF">James De Raja</text>
+</svg>

--- a/mockups/mockup.request.json
+++ b/mockups/mockup.request.json
@@ -1,0 +1,6 @@
+{
+  "action": "generate_mockups",
+  "formats": ["svg", "png"],
+  "themes": ["minimal-professional", "creative-bold", "modern-monochrome", "soft-pastel"],
+  "page_modes": ["letter", "a4"]
+}

--- a/resume/data/content.json
+++ b/resume/data/content.json
@@ -1,0 +1,17 @@
+{
+  "name": "James De Raja",
+  "headline": "Senior Unity Developer",
+  "specialization": "Performance Optimization • AR/VR/XR • Rendering • Frame Stability",
+  "summary": "Senior Unity performance engineer with 13+ years optimizing rendering pipelines, frame pacing, and CPU/GPU bottlenecks for mobile and XR under strict 11 ms / 72–90 Hz budgets.",
+  "availability": "Open to remote & relocation for rendering, XR performance, and engine optimization roles.",
+  "location": "UNSPECIFIED",
+  "email": "UNSPECIFIED",
+  "linkedin": "UNSPECIFIED",
+  "github": "UNSPECIFIED",
+  "resume_pdf": "/resume/james-de-raja-resume.pdf",
+  "metrics": [
+    { "value": "13+ years", "label": "Unity performance engineering" },
+    { "value": "72/90 Hz", "label": "XR budget discipline" },
+    { "value": "100+", "label": "rapid prototypes delivered" }
+  ]
+}

--- a/resume/data/tokens.json
+++ b/resume/data/tokens.json
@@ -1,0 +1,99 @@
+{
+  "resume": {
+    "default_theme": "minimal-professional",
+    "page": "letter",
+    "grid": {
+      "columns": 12,
+      "gap": "16px",
+      "radius": "16px",
+      "padding": "18px",
+      "auto_rows": "minmax(88px, auto)"
+    },
+    "themes": {
+      "minimal-professional": {
+        "fonts": {
+          "display": "\"Source Serif 4\", Georgia, serif",
+          "body": "Inter, system-ui, sans-serif",
+          "mono": "ui-monospace, SFMono-Regular, Menlo, monospace"
+        },
+        "colors": {
+          "primary": "#0F172A",
+          "secondary": "#1D4ED8",
+          "accent": "#0F766E",
+          "background": "#F8FAFC",
+          "neutral": "#64748B",
+          "border": "#CBD5E1",
+          "surface1": "#FFFFFF",
+          "surface2": "#EFF6FF",
+          "heroBg": "#0F172A",
+          "heroFg": "#FFFFFF",
+          "accentBg": "#ECFEFF",
+          "accentFg": "#0F172A"
+        }
+      },
+      "creative-bold": {
+        "fonts": {
+          "display": "\"IBM Plex Sans\", Arial, sans-serif",
+          "body": "\"IBM Plex Sans\", Arial, sans-serif",
+          "mono": "\"IBM Plex Mono\", ui-monospace, monospace"
+        },
+        "colors": {
+          "primary": "#111827",
+          "secondary": "#6D28D9",
+          "accent": "#B45309",
+          "background": "#FFF7ED",
+          "neutral": "#475569",
+          "border": "#D6D3D1",
+          "surface1": "#FFFFFF",
+          "surface2": "#FFEDD5",
+          "heroBg": "#6D28D9",
+          "heroFg": "#FFFFFF",
+          "accentBg": "#FFEDD5",
+          "accentFg": "#111827"
+        }
+      },
+      "modern-monochrome": {
+        "fonts": {
+          "display": "\"Atkinson Hyperlegible Next\", Arial, sans-serif",
+          "body": "\"Atkinson Hyperlegible Next\", Arial, sans-serif",
+          "mono": "\"IBM Plex Mono\", ui-monospace, monospace"
+        },
+        "colors": {
+          "primary": "#111111",
+          "secondary": "#2F2F2F",
+          "accent": "#4B5563",
+          "background": "#FFFFFF",
+          "neutral": "#6B7280",
+          "border": "#D1D5DB",
+          "surface1": "#FFFFFF",
+          "surface2": "#F5F5F5",
+          "heroBg": "#111111",
+          "heroFg": "#FFFFFF",
+          "accentBg": "#F5F5F5",
+          "accentFg": "#111111"
+        }
+      },
+      "soft-pastel": {
+        "fonts": {
+          "display": "\"Newsreader\", Georgia, serif",
+          "body": "Inter, system-ui, sans-serif",
+          "mono": "ui-monospace, SFMono-Regular, Menlo, monospace"
+        },
+        "colors": {
+          "primary": "#1F2937",
+          "secondary": "#0F766E",
+          "accent": "#6D28D9",
+          "background": "#FFF8F5",
+          "neutral": "#9A8C82",
+          "border": "#E7D6D1",
+          "surface1": "#FFFFFF",
+          "surface2": "#FCE7F3",
+          "heroBg": "#FCE7F3",
+          "heroFg": "#1F2937",
+          "accentBg": "#ECFDF5",
+          "accentFg": "#1F2937"
+        }
+      }
+    }
+  }
+}

--- a/resume/index.html
+++ b/resume/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en-US">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>James De Raja — Senior Unity Developer</title>
+  <link rel="stylesheet" href="./styles/resume.css" />
+</head>
+<body data-theme="minimal-professional" data-page="letter">
+  <article class="resume" aria-labelledby="resume-name">
+    <header class="card hero span-8">
+      <p class="eyebrow">Senior Unity Developer</p>
+      <h1 id="resume-name">James De Raja</h1>
+      <p class="lede">Performance Optimization • AR/VR/XR • Rendering • Frame Stability</p>
+      <p class="summary">13+ years optimizing Unity rendering pipelines, frame pacing, and CPU/GPU bottlenecks for mobile and XR under strict 11 ms / 72–90 Hz budgets.</p>
+      <nav class="cta-strip" aria-label="Primary recruiter actions">
+        <a class="btn btn-primary" href="/resume/james-de-raja-resume.pdf">Download Resume PDF</a>
+        <a class="btn btn-secondary" href="/#work">View Case Studies</a>
+        <a class="btn btn-ghost" href="mailto:UNSPECIFIED">Email</a>
+      </nav>
+    </header>
+
+    <section class="card span-4"><h2 class="section-title">Impact</h2></section>
+    <section class="card span-8"><h2 class="section-title">Experience</h2></section>
+    <section class="card span-4"><h2 class="section-title">Skills</h2></section>
+    <section class="card span-6"><h2 class="section-title">XR Performance Stress Lab</h2></section>
+    <section class="card span-6"><h2 class="section-title">SoftMaskPro</h2></section>
+    <section class="card span-4"><h2 class="section-title">CTA/Contact</h2></section>
+  </article>
+</body>
+</html>

--- a/resume/partials/cta-strip.html
+++ b/resume/partials/cta-strip.html
@@ -1,0 +1,7 @@
+<nav class="cta-strip" aria-label="Primary recruiter actions">
+  <a class="btn btn-primary" href="/resume/james-de-raja-resume.pdf">Download Resume PDF</a>
+  <a class="btn btn-secondary" href="/#work">View Case Studies</a>
+  <a class="btn btn-ghost" href="mailto:UNSPECIFIED">Email</a>
+  <a class="btn btn-ghost" href="UNSPECIFIED">LinkedIn</a>
+  <a class="btn btn-ghost" href="UNSPECIFIED">GitHub</a>
+</nav>

--- a/resume/styles/resume.css
+++ b/resume/styles/resume.css
@@ -1,0 +1,18 @@
+:root {
+  --color-primary: #0F172A;
+  --color-bg: #F8FAFC;
+  --color-border: #CBD5E1;
+  --hero-bg: #0F172A;
+  --hero-fg: #FFFFFF;
+}
+* { box-sizing: border-box; }
+body { margin: 0; padding: 24px; background: var(--color-bg); color: var(--color-primary); font-family: Inter, system-ui, sans-serif; }
+.resume { max-width: 1100px; margin: 0 auto; display: grid; grid-template-columns: repeat(12,minmax(0,1fr)); gap: 16px; }
+.card { background: #fff; border: 1px solid var(--color-border); border-radius: 16px; padding: 18px; }
+.hero { background: var(--hero-bg); color: var(--hero-fg); }
+.span-4 { grid-column: span 4; } .span-6 { grid-column: span 6; } .span-8 { grid-column: span 8; }
+.cta-strip { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 12px; }
+.btn { border-radius: 999px; padding: 10px 14px; text-decoration: none; }
+.btn-primary { background: white; color: #0F172A; }
+.btn-secondary,.btn-ghost { border: 1px solid rgba(255,255,255,0.4); color: white; }
+@media (max-width:960px){ .resume{grid-template-columns:1fr;} .span-4,.span-6,.span-8{grid-column:auto;} }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,7 +9,8 @@ export default function Footer() {
           <SmartLink href="mailto:jamesderaja@gmail.com" className="transition hover:text-neon">Email</SmartLink>
           <SmartLink href="https://www.linkedin.com/in/james-de-raja/" className="transition hover:text-neon">LinkedIn</SmartLink>
           <SmartLink href="https://github.com/JamesDeRaja" className="transition hover:text-neon">GitHub</SmartLink>
-          <SmartLink href="/resume/viewer.html?file=JamesDeRaja_Resume.pdf" className="transition hover:text-neon">Resume</SmartLink>
+          <SmartLink href="/resume/viewer.html?file=JamesDeRaja_Resume.pdf" className="transition hover:text-neon">Resume PDF</SmartLink>
+          <SmartLink href="/#work" className="transition hover:text-neon">Case Studies</SmartLink>
         </div>
       </div>
     </footer>

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -4,7 +4,7 @@ export const workProjects: WorkProject[] = [
   {
     id: 'xr-stress-lab',
     title: 'XR Performance Stress Lab',
-    summary: 'Profiler-led test harness for isolating XR rendering and frame pacing constraints.',
+    summary: 'Profiler-led XR frame-budget isolation and frame pacing analysis.',
     highlights: [
       'Reduced submission + skinning cost via dynamic skinned-mesh chunking.',
       'Protected culling/occlusion behavior with spatially coherent grouping + visibility gating.'
@@ -19,8 +19,8 @@ export const workProjects: WorkProject[] = [
   },
   {
     id: 'softmaskpro',
-    title: 'SoftMaskPro (Unity UI Rendering Tooling)',
-    summary: 'Rendering-adjacent UI masking toolkit focused on predictable cost under load.',
+    title: 'SoftMaskPro',
+    summary: 'UI masking cost isolation, fill-rate profiling, and redraw-path reduction.',
     highlights: [
       'Profiled mask passes against fill-rate heavy UI scenes.',
       'Reduced unnecessary redraw paths through targeted update logic.',

--- a/src/sections/HeroSection.tsx
+++ b/src/sections/HeroSection.tsx
@@ -83,13 +83,13 @@ export default function HeroSection() {
             variants={itemVariants}
             className="mt-4 text-xl font-semibold text-neon/90 sm:text-2xl lg:text-3xl"
           >
-            Real-Time Performance Engineer
+            Senior Unity Developer — Performance Optimization, AR/VR/XR, Rendering, Frame Stability
           </motion.p>
           <motion.p
             variants={itemVariants}
             className="mt-1 text-base text-slate-400 sm:text-lg"
           >
-            Unity Rendering &bull; Frame Stability &bull; XR / Mobile / Shipped Titles
+            13+ years optimizing Unity rendering pipelines, frame pacing, and CPU/GPU bottlenecks for mobile and XR under strict 11 ms / 72–90 Hz budgets.
           </motion.p>
 
           {/* Value prop */}
@@ -97,9 +97,8 @@ export default function HeroSection() {
             variants={itemVariants}
             className="mt-8 max-w-2xl text-lg text-slate-200 leading-relaxed sm:text-xl"
           >
-            Delivered 100+ rapid prototypes and production titles for global publishers across 13+ years in Unity.
-            I find the bottleneck, prove it with a profiler, fix it, and{' '}
-            <span className="text-neon font-semibold">ship it at 60fps</span>.
+            Senior Unity performance engineer focused on proof-first optimization: isolate bottlenecks with profiler evidence,
+            stabilize frame pacing, and ship rendering improvements that hold under XR and mobile budgets.
           </motion.p>
 
           {/* Impact proof */}
@@ -123,23 +122,23 @@ export default function HeroSection() {
             className="mt-12 flex flex-wrap gap-4"
           >
             <a
-              href="#problems-solved"
+              href="/resume/JamesDeRaja_Resume_XR-Performance-Engineer.pdf"
               className="btn-primary group inline-flex items-center gap-2 rounded-xl px-6 py-3 text-sm font-medium"
             >
-              See Problems I Fixed
+              Download Resume PDF
               <ArrowRight size={14} className="transition group-hover:translate-x-1" />
             </a>
             <a
-              href="#shipped-titles"
+              href="#work"
               className="btn-secondary rounded-xl px-6 py-3 text-sm font-medium"
             >
-              Shipped Games
+              View Case Studies
             </a>
             <a
               href="#xr-lab"
               className="btn-secondary rounded-xl px-6 py-3 text-sm font-medium"
             >
-              XR Lab
+              View XR Case Studies
             </a>
           </motion.div>
         </motion.div>


### PR DESCRIPTION
### Motivation
- Convert the portfolio-first homepage into a recruiter-first, proof-first resume flow that highlights senior Unity/XR performance expertise and places a resume CTA above the fold.
- Surface the strongest proof artifacts (XR Stress Lab, SoftMaskPro) as concise, recruiter-readable case statements rather than portfolio blurbs.
- Provide a separate, paste-ready resume build target so resume export and accessibility checks can happen independently of the main site.
- Preserve any missing/verified fields as `UNSPECIFIED` so measured metrics and chronology can be filled later.

### Description
- Updated homepage hero messaging and CTAs in `src/sections/HeroSection.tsx` to a recruiter-first headline, proof-first lede, and CTAs: `Download Resume PDF`, `View Case Studies`, `View XR Case Studies`.
- Tightened case/project copy in `src/data/projects.ts` for `XR Performance Stress Lab` and `SoftMaskPro` to emphasize frame-budget isolation, fill-rate profiling, and redraw-path reduction.
- Expanded footer links in `src/components/Footer.tsx` to include `Resume PDF` and `Case Studies` alongside Email/LinkedIn/GitHub.
- Added a standalone `resume/` bento-resume scaffold (`resume/index.html`, `resume/styles/resume.css`, `resume/data/tokens.json`, `resume/data/content.json`, `resume/partials/cta-strip.html`) and simple mockup artifacts in `mockups/` to support export and design handoff.

### Testing
- Ran the production build with `npm run build`, which completed successfully (Vite build passed).
- No automated screenshot or browser-based accessibility export was executed in this run (screenshot/print steps remain manual or for CI with headless browser).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebadd6cfac8324b1a30688f0378364)