### PR TITLE
Refine portfolio copy for clearer recruiter-facing messaging

### DIFF
--- a/src/sections/CaseStudiesBentoSection.tsx
+++ b/src/sections/CaseStudiesBentoSection.tsx
@@ -248,7 +248,7 @@ export default function CaseStudiesBentoSection() {
               <p className="text-sm text-slate-300 leading-relaxed">
                 A controlled Unity 6 / URP / OpenXR benchmarking framework. One toggle introduces
                 the variable — everything else stays locked. Built to prove bottleneck type (GPU fragment,
-                bandwidth, or submission) with profiler captures, not guesses.
+                bandwidth, or submission) with profiler captures, not guesswork.
               </p>
 
               <div className="rounded-xl border border-amber-500/20 bg-amber-500/[0.06] px-4 py-3">

--- a/src/sections/ContactBentoSection.tsx
+++ b/src/sections/ContactBentoSection.tsx
@@ -64,7 +64,7 @@ export default function ContactBentoSection() {
         </h2>
         <p className="mt-2 max-w-2xl text-sm text-slate-400 leading-relaxed">
           Open to remote roles worldwide and international relocation. Senior Unity, XR, and rendering
-          engineering positions where profiler evidence matters more than marketing slides.
+          engineering positions where measurable performance evidence is a priority.
         </p>
       </motion.div>
 
@@ -111,8 +111,8 @@ export default function ContactBentoSection() {
             <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-4">
               <p className="text-sm text-slate-300 leading-relaxed">
                 Targeting rendering, XR performance, and real-time systems engineering roles — teams
-                where frame budget discipline and profiler evidence are engineering requirements, not
-                afterthoughts.
+                that prioritize frame budget discipline and profiler evidence as core engineering
+                requirements.
               </p>
               <div className="mt-3 flex flex-wrap gap-1.5">
                 {targetRoles.map((role) => (

--- a/src/sections/ContactSection.tsx
+++ b/src/sections/ContactSection.tsx
@@ -36,7 +36,7 @@ export default function ContactSection() {
           {/* Positioning statement */}
           <p className="text-base text-slate-300 leading-relaxed">
             I&apos;m targeting rendering, XR performance, and engine optimization roles —
-            teams where profiler evidence matters more than marketing slides.
+            teams where measurable performance evidence is a priority.
             Open to <span className="font-medium text-white">remote work worldwide</span> and{' '}
             <span className="font-medium text-white">international relocation</span>.
           </p>

--- a/src/sections/EvidenceBentoSection.tsx
+++ b/src/sections/EvidenceBentoSection.tsx
@@ -82,7 +82,7 @@ export default function EvidenceBentoSection() {
           Evidence, Not Claims
         </p>
         <h2 className="mt-2 text-2xl font-bold text-white sm:text-3xl">
-          Profiler screenshots, not marketing slides
+          Profiler screenshots and measured data
         </h2>
         <p className="mt-2 max-w-2xl text-sm text-slate-400 leading-relaxed">
           Every performance statement on this site is backed by a profiler screenshot, a Frame Debugger

--- a/src/sections/HeroBentoSection.tsx
+++ b/src/sections/HeroBentoSection.tsx
@@ -257,7 +257,7 @@ export default function HeroBentoSection() {
                 </div>
               </div>
               <div className="mt-4 pt-3 border-t border-white/[0.05] flex items-center justify-between">
-                <p className="text-[11px] text-slate-500">CPI & D1 retention across rapid iteration</p>
+                <p className="text-[11px] text-slate-500">CPI (cost per install) and D1 retention across rapid iteration</p>
                 <ExternalLink size={10} className="text-slate-600 group-hover:text-emerald-400 transition-colors" />
               </div>
             </BentoCard>
@@ -306,7 +306,7 @@ export default function HeroBentoSection() {
                   and engineering evidence that ships.
                 </p>
                 <div className="mt-4 flex flex-wrap gap-1.5">
-                  {['Profiler-validated', 'Frame-budget aware', 'Deterministic benchmarks', 'Baseline vs stress'].map((tag) => (
+                  {['Profiler-validated', 'Frame budget aware', 'Deterministic benchmarks', 'Baseline vs stress'].map((tag) => (
                     <span
                       key={tag}
                       className="inline-block rounded border border-electric/15 bg-electric/[0.05] px-2 py-0.5 font-mono text-[11px] text-electric/80"

--- a/src/sections/TechFocusBentoSection.tsx
+++ b/src/sections/TechFocusBentoSection.tsx
@@ -95,7 +95,7 @@ const techCards: TechCard[] = [
   },
   {
     title: 'ECS / DOTS Direction',
-    body: 'Data-oriented design applied to game object management — structure-of-arrays memory layout, job system parallelism, and Burst-compiled hot paths for agent-dense scenarios where MonoBehaviour update budgets collapse.',
+    body: 'Data-oriented design applied to game object management — structure-of-arrays memory layout, job system parallelism, and Burst-compiled hot paths for agent-dense scenarios where MonoBehaviour update budgets become inadequate.',
     keywords: ['ECS', 'DOTS', 'Burst compiler', 'Job System', 'data-oriented'],
     accent: 'green',
     icon: GitMerge,


### PR DESCRIPTION
### Motivation
- Make the portfolio wording more recruiter- and non-technical-reader friendly while preserving the proof-first, data-backed engineering message. 
- Reduce phrasing that can sound adversarial to HR or non-technical screeners and improve clarity for international applicants. 

### Description
- Reworded recruiter-facing and evidence language across site sections to a neutral, measurable framing, updating `src/sections/ContactBentoSection.tsx` and `src/sections/ContactSection.tsx` to emphasize "measurable performance evidence" and prioritize frame-budget discipline as core requirements. 
- Clarified the XR lab copy in `src/sections/CaseStudiesBentoSection.tsx` by changing "not guesses" to "not guesswork" to keep tone professional and precise. 
- Replaced the Evidence section heading in `src/sections/EvidenceBentoSection.tsx` from "Profiler screenshots, not marketing slides" to "Profiler screenshots and measured data" to broaden the appeal to non-technical readers. 
- Softened technical phrasing in `src/sections/TechFocusBentoSection.tsx` from "update budgets collapse" to "become inadequate", standardized the tag wording to "Frame budget aware" and expanded `CPI` to "CPI (cost per install)" in `src/sections/HeroBentoSection.tsx` for clearer accessibility. 
- Files modified: `src/sections/CaseStudiesBentoSection.tsx`, `src/sections/EvidenceBentoSection.tsx`, `src/sections/TechFocusBentoSection.tsx`, `src/sections/ContactBentoSection.tsx`, `src/sections/HeroBentoSection.tsx`, and `src/sections/ContactSection.tsx`. 

### Testing
- Ran the production build with `npm run build`, which completed successfully and produced the `dist` output. 
- The build emitted non-blocking warnings about an outdated Browserslist DB and some large chunk sizes, but the build finished without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee402593d483249e45b3bf8c861cee)