### PR TITLE
Improve selection visibility and add light-theme particle contrast

### DIFF
--- a/src/components/ParticleField.tsx
+++ b/src/components/ParticleField.tsx
@@ -10,11 +10,15 @@ type Particle = {
   hue: number;
 };
 
+type ParticleFieldProps = {
+  theme?: 'dark' | 'light';
+};
+
 const MAX_DPR = 1.75;
 const CONNECTION_DISTANCE = 150;
 const CONNECTION_DISTANCE_SQ = CONNECTION_DISTANCE * CONNECTION_DISTANCE;
 
-export default function ParticleField() {
+export default function ParticleField({ theme = 'dark' }: ParticleFieldProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const animationRef = useRef<number>(0);
   const particlesRef = useRef<Particle[]>([]);
@@ -49,14 +53,15 @@ export default function ParticleField() {
 
     const createParticles = () => {
       const count = Math.min(70, Math.floor(window.innerWidth / 24));
+      const isLightTheme = theme === 'light';
       particlesRef.current = Array.from({ length: count }, () => ({
         x: Math.random() * window.innerWidth,
         y: Math.random() * window.innerHeight,
         vx: (Math.random() - 0.5) * 0.3,
         vy: (Math.random() - 0.5) * 0.3,
         size: Math.random() * 2 + 0.5,
-        opacity: Math.random() * 0.45 + 0.12,
-        hue: Math.random() > 0.72 ? 270 : 185,
+        opacity: isLightTheme ? Math.random() * 0.28 + 0.2 : Math.random() * 0.45 + 0.12,
+        hue: Math.random() > 0.72 ? 270 : isLightTheme ? 225 : 185,
       }));
     };
 
@@ -97,6 +102,9 @@ export default function ParticleField() {
 
       ctx.clearRect(0, 0, width, height);
       const particles = particlesRef.current;
+      const isLightTheme = theme === 'light';
+      const particleLightness = isLightTheme ? '52%' : '70%';
+      const lineLightness = isLightTheme ? '46%' : '70%';
       const mouse = mouseRef.current;
 
       for (let i = 0; i < particles.length; i++) {
@@ -112,7 +120,7 @@ export default function ParticleField() {
 
         ctx.beginPath();
         ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
-        ctx.fillStyle = `hsla(${p.hue}, 100%, 70%, ${p.opacity})`;
+        ctx.fillStyle = `hsla(${p.hue}, 100%, ${particleLightness}, ${p.opacity})`;
         ctx.fill();
 
         for (let j = i + 1; j < particles.length; j++) {
@@ -123,11 +131,12 @@ export default function ParticleField() {
 
           if (distSq < CONNECTION_DISTANCE_SQ) {
             const dist = Math.sqrt(distSq);
-            const alpha = 0.055 * (1 - dist / CONNECTION_DISTANCE);
+            const alphaBase = isLightTheme ? 0.095 : 0.055;
+            const alpha = alphaBase * (1 - dist / CONNECTION_DISTANCE);
             ctx.beginPath();
             ctx.moveTo(p.x, p.y);
             ctx.lineTo(p2.x, p2.y);
-            ctx.strokeStyle = `hsla(185, 100%, 70%, ${alpha})`;
+            ctx.strokeStyle = `hsla(${isLightTheme ? 225 : 185}, 100%, ${lineLightness}, ${alpha})`;
             ctx.lineWidth = 0.5;
             ctx.stroke();
           }
@@ -167,13 +176,13 @@ export default function ParticleField() {
       cancelAnimationFrame(resizeRaf);
       animationRef.current = 0;
     };
-  }, []);
+  }, [theme]);
 
   return (
     <canvas
       ref={canvasRef}
       className="pointer-events-none fixed inset-0 z-0 particle-canvas"
-      style={{ opacity: 0.55 }}
+      style={{ opacity: theme === 'light' ? 0.78 : 0.55 }}
       aria-hidden="true"
     />
   );

--- a/src/index.css
+++ b/src/index.css
@@ -13,6 +13,8 @@
   --void-700: 17 17 39;
   --neon: 129 140 248;
   --electric: 167 139 250;
+  --selection-bg: 129 140 248;
+  --selection-text: 255 255 255;
 
   color: #e2e8f0;
   background-color: rgb(var(--void-950));
@@ -28,6 +30,8 @@
   --void-700: 220 219 240;   /* #dcdbe0 — subtle border/divider */
   --neon: 99 102 241;
   --electric: 109 40 217;
+  --selection-bg: 99 102 241;
+  --selection-text: 15 23 42;
 
   color: #18181f;            /* near-black with the faintest blue — premium charcoal */
   color-scheme: light;
@@ -46,8 +50,8 @@ body {
 
 /* ── Selection color ── */
 ::selection {
-  background-color: rgba(var(--neon), 0.2);
-  color: #fff;
+  background-color: rgba(var(--selection-bg), 0.35);
+  color: rgb(var(--selection-text));
 }
 
 /* ── Scrollbar ── */

--- a/src/index.css
+++ b/src/index.css
@@ -15,6 +15,7 @@
   --electric: 167 139 250;
   --selection-bg: 129 140 248;
   --selection-text: 255 255 255;
+  --selection-link-text: 255 255 255;
 
   color: #e2e8f0;
   background-color: rgb(var(--void-950));
@@ -32,6 +33,7 @@
   --electric: 109 40 217;
   --selection-bg: 99 102 241;
   --selection-text: 15 23 42;
+  --selection-link-text: 15 23 42;
 
   color: #18181f;            /* near-black with the faintest blue — premium charcoal */
   color-scheme: light;
@@ -49,9 +51,16 @@ body {
 }
 
 /* ── Selection color ── */
-::selection {
+*::selection {
   background-color: rgba(var(--selection-bg), 0.35);
   color: rgb(var(--selection-text));
+}
+
+a::selection,
+a *::selection {
+  background-color: rgba(var(--selection-bg), 0.5);
+  color: rgb(var(--selection-link-text));
+  -webkit-text-fill-color: rgb(var(--selection-link-text));
 }
 
 /* ── Scrollbar ── */

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -9,9 +9,11 @@ import EvidenceBentoSection from '../sections/EvidenceBentoSection';
 import ExperienceBentoSection from '../sections/ExperienceBentoSection';
 import SkillsBentoSection from '../sections/SkillsBentoSection';
 import ContactBentoSection from '../sections/ContactBentoSection';
+import { useTheme } from '../contexts/ThemeContext';
 
 export default function HomePage() {
   const location = useLocation();
+  const { theme } = useTheme();
 
   useEffect(() => {
     const hash = location.hash.replace('#', '');
@@ -32,7 +34,7 @@ export default function HomePage() {
       />
 
       {/* Particle background */}
-      <ParticleField />
+      <ParticleField theme={theme} />
 
       {/* Grid overlay */}
       <div className="pointer-events-none fixed inset-0 z-0 bg-grid-overlay" aria-hidden="true" />

--- a/src/sections/ContactBentoSection.tsx
+++ b/src/sections/ContactBentoSection.tsx
@@ -151,7 +151,7 @@ export default function ContactBentoSection() {
                   >
                     <div className="flex items-center gap-2.5">
                       <FileText size={13} className="text-slate-500 group-hover:text-neon transition-colors" />
-                      <span className="text-xs text-slate-300 group-hover:text-white transition-colors">
+                      <span className="text-xs text-slate-300 transition-colors">
                         {r.label}
                       </span>
                     </div>


### PR DESCRIPTION
### Motivation
- Fix global text-selection styling that made selections hard to see in dark mode and effectively invisible in light mode.
- Restore the ambient particle background effect in light theme so the site has consistent visual treatment across themes.

### Description
- Updated `src/index.css` to introduce `--selection-bg` and `--selection-text` variables for both dark and light themes and changed `::selection` to use them for consistent readable selections.
- Extended `src/components/ParticleField.tsx` with an optional `theme` prop and made particle hue, opacity, connection-line alpha/lightness, and canvas opacity theme-aware so particles are visible in light mode.
- Made the particle effect `useEffect` depend on `theme` so the canvas is recreated/tuned when the user toggles themes.
- Wired `src/pages/HomePage.tsx` to read the current theme from `useTheme()` and pass it into `<ParticleField />`.

### Testing
- Ran `npm run build` and the production build completed successfully.
- Ran `npm run lint` which failed due to an existing unused-variable error in `src/caseStudies/pages/SoftMaskProCaseStudyPage.tsx` that is unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eef097103883249a75981b91b4cc80)