### PR TITLE
Theme-aware particle background, selection styling, and hero layout refinements

### DIFF
--- a/src/components/ParticleField.tsx
+++ b/src/components/ParticleField.tsx
@@ -10,11 +10,15 @@ type Particle = {
   hue: number;
 };
 
+type ParticleFieldProps = {
+  theme?: 'dark' | 'light';
+};
+
 const MAX_DPR = 1.75;
 const CONNECTION_DISTANCE = 150;
 const CONNECTION_DISTANCE_SQ = CONNECTION_DISTANCE * CONNECTION_DISTANCE;
 
-export default function ParticleField() {
+export default function ParticleField({ theme = 'dark' }: ParticleFieldProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const animationRef = useRef<number>(0);
   const particlesRef = useRef<Particle[]>([]);
@@ -49,14 +53,15 @@ export default function ParticleField() {
 
     const createParticles = () => {
       const count = Math.min(70, Math.floor(window.innerWidth / 24));
+      const isLightTheme = theme === 'light';
       particlesRef.current = Array.from({ length: count }, () => ({
         x: Math.random() * window.innerWidth,
         y: Math.random() * window.innerHeight,
         vx: (Math.random() - 0.5) * 0.3,
         vy: (Math.random() - 0.5) * 0.3,
         size: Math.random() * 2 + 0.5,
-        opacity: Math.random() * 0.45 + 0.12,
-        hue: Math.random() > 0.72 ? 270 : 185,
+        opacity: isLightTheme ? Math.random() * 0.28 + 0.2 : Math.random() * 0.45 + 0.12,
+        hue: Math.random() > 0.72 ? 270 : isLightTheme ? 225 : 185,
       }));
     };
 
@@ -97,6 +102,9 @@ export default function ParticleField() {
 
       ctx.clearRect(0, 0, width, height);
       const particles = particlesRef.current;
+      const isLightTheme = theme === 'light';
+      const particleLightness = isLightTheme ? '52%' : '70%';
+      const lineLightness = isLightTheme ? '46%' : '70%';
       const mouse = mouseRef.current;
 
       for (let i = 0; i < particles.length; i++) {
@@ -112,7 +120,7 @@ export default function ParticleField() {
 
         ctx.beginPath();
         ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
-        ctx.fillStyle = `hsla(${p.hue}, 100%, 70%, ${p.opacity})`;
+        ctx.fillStyle = `hsla(${p.hue}, 100%, ${particleLightness}, ${p.opacity})`;
         ctx.fill();
 
         for (let j = i + 1; j < particles.length; j++) {
@@ -123,11 +131,12 @@ export default function ParticleField() {
 
           if (distSq < CONNECTION_DISTANCE_SQ) {
             const dist = Math.sqrt(distSq);
-            const alpha = 0.055 * (1 - dist / CONNECTION_DISTANCE);
+            const alphaBase = isLightTheme ? 0.095 : 0.055;
+            const alpha = alphaBase * (1 - dist / CONNECTION_DISTANCE);
             ctx.beginPath();
             ctx.moveTo(p.x, p.y);
             ctx.lineTo(p2.x, p2.y);
-            ctx.strokeStyle = `hsla(185, 100%, 70%, ${alpha})`;
+            ctx.strokeStyle = `hsla(${isLightTheme ? 225 : 185}, 100%, ${lineLightness}, ${alpha})`;
             ctx.lineWidth = 0.5;
             ctx.stroke();
           }
@@ -167,13 +176,13 @@ export default function ParticleField() {
       cancelAnimationFrame(resizeRaf);
       animationRef.current = 0;
     };
-  }, []);
+  }, [theme]);
 
   return (
     <canvas
       ref={canvasRef}
       className="pointer-events-none fixed inset-0 z-0 particle-canvas"
-      style={{ opacity: 0.55 }}
+      style={{ opacity: theme === 'light' ? 0.78 : 0.55 }}
       aria-hidden="true"
     />
   );

--- a/src/index.css
+++ b/src/index.css
@@ -13,6 +13,9 @@
   --void-700: 17 17 39;
   --neon: 129 140 248;
   --electric: 167 139 250;
+  --selection-bg: 129 140 248;
+  --selection-text: 255 255 255;
+  --selection-link-text: 255 255 255;
 
   color: #e2e8f0;
   background-color: rgb(var(--void-950));
@@ -28,6 +31,9 @@
   --void-700: 220 219 240;   /* #dcdbe0 — subtle border/divider */
   --neon: 99 102 241;
   --electric: 109 40 217;
+  --selection-bg: 99 102 241;
+  --selection-text: 15 23 42;
+  --selection-link-text: 15 23 42;
 
   color: #18181f;            /* near-black with the faintest blue — premium charcoal */
   color-scheme: light;
@@ -45,9 +51,16 @@ body {
 }
 
 /* ── Selection color ── */
-::selection {
-  background-color: rgba(var(--neon), 0.2);
-  color: #fff;
+*::selection {
+  background-color: rgba(var(--selection-bg), 0.35);
+  color: rgb(var(--selection-text));
+}
+
+a::selection,
+a *::selection {
+  background-color: rgba(var(--selection-bg), 0.5);
+  color: rgb(var(--selection-link-text));
+  -webkit-text-fill-color: rgb(var(--selection-link-text));
 }
 
 /* ── Scrollbar ── */

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -9,9 +9,11 @@ import EvidenceBentoSection from '../sections/EvidenceBentoSection';
 import ExperienceBentoSection from '../sections/ExperienceBentoSection';
 import SkillsBentoSection from '../sections/SkillsBentoSection';
 import ContactBentoSection from '../sections/ContactBentoSection';
+import { useTheme } from '../contexts/ThemeContext';
 
 export default function HomePage() {
   const location = useLocation();
+  const { theme } = useTheme();
 
   useEffect(() => {
     const hash = location.hash.replace('#', '');
@@ -32,7 +34,7 @@ export default function HomePage() {
       />
 
       {/* Particle background */}
-      <ParticleField />
+      <ParticleField theme={theme} />
 
       {/* Grid overlay */}
       <div className="pointer-events-none fixed inset-0 z-0 bg-grid-overlay" aria-hidden="true" />

--- a/src/sections/ContactBentoSection.tsx
+++ b/src/sections/ContactBentoSection.tsx
@@ -151,7 +151,7 @@ export default function ContactBentoSection() {
                   >
                     <div className="flex items-center gap-2.5">
                       <FileText size={13} className="text-slate-500 group-hover:text-neon transition-colors" />
-                      <span className="text-xs text-slate-300 group-hover:text-white transition-colors">
+                      <span className="text-xs text-slate-300 transition-colors">
                         {r.label}
                       </span>
                     </div>

--- a/src/sections/HeroBentoSection.tsx
+++ b/src/sections/HeroBentoSection.tsx
@@ -76,13 +76,13 @@ export default function HeroBentoSection() {
               </div>
 
               {/* Identity + title */}
-              <div className="flex items-start gap-4 sm:gap-5">
+              <div className="flex items-start gap-4 sm:gap-6">
                 <div className="relative flex-shrink-0">
-                  <div className="absolute -inset-1.5 rounded-xl bg-neon/10 blur-lg" aria-hidden="true" />
+                  <div className="absolute -inset-2 rounded-2xl bg-neon/10 blur-lg" aria-hidden="true" />
                   <img
                     src="/images/james.jpg"
                     alt="James De Raja"
-                    className="relative h-20 w-20 sm:h-24 sm:w-24 lg:h-24 lg:w-24 rounded-xl object-cover ring-1 ring-neon/25 shadow-[0_0_20px_rgba(129,140,248,0.2)]"
+                    className="relative h-24 w-24 sm:h-28 sm:w-28 lg:h-[140px] lg:w-[140px] rounded-2xl object-cover ring-1 ring-neon/25 shadow-[0_0_20px_rgba(129,140,248,0.2)]"
                   />
                 </div>
                 <div>

--- a/src/sections/HeroBentoSection.tsx
+++ b/src/sections/HeroBentoSection.tsx
@@ -67,33 +67,36 @@ export default function HeroBentoSection() {
         >
           <BentoCard variant="featured" padding="lg" elevated className="h-full flex flex-col justify-between gap-7">
             <div className="space-y-5">
-              {/* Top row: badge + photo */}
+              {/* Top row: availability badge */}
               <div className="flex items-start justify-between gap-4">
                 <span className="inline-flex items-center gap-2 rounded-full border border-emerald-500/25 bg-emerald-500/[0.06] px-3 py-1 text-xs font-medium text-emerald-400">
                   <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 animate-pulse" />
                   Open to senior roles — Unity Rendering / XR Performance
                 </span>
-                <div className="hidden sm:block flex-shrink-0">
+              </div>
+
+              {/* Identity + title */}
+              <div className="flex items-start gap-4 sm:gap-5">
+                <div className="relative mt-1 flex-shrink-0">
+                  <div className="absolute -inset-2 rounded-2xl bg-neon/10 blur-xl" aria-hidden="true" />
                   <img
                     src="/images/james.jpg"
                     alt="James De Raja"
-                    className="h-16 w-16 rounded-xl object-cover ring-1 ring-neon/20 shadow-[0_0_16px_rgba(0,240,255,0.1)]"
+                    className="relative h-20 w-20 sm:h-24 sm:w-24 lg:h-28 lg:w-28 rounded-2xl object-cover ring-1 ring-neon/25 shadow-[0_0_24px_rgba(129,140,248,0.22)]"
                   />
                 </div>
-              </div>
-
-              {/* Name + title */}
-              <div>
-                <h1 className="text-4xl font-bold tracking-tight text-white sm:text-5xl lg:text-6xl">
-                  James{' '}
-                  <span className="gradient-text">De Raja</span>
-                </h1>
-                <p className="mt-3 text-xl font-semibold text-white/90 sm:text-2xl">
-                  Senior Real-Time Performance Engineer
-                </p>
-                <p className="mt-1.5 font-mono text-sm text-neon/80">
-                  Unity Rendering&nbsp;&bull;&nbsp;XR Frame Budgets&nbsp;&bull;&nbsp;CPU/GPU Bottleneck Isolation
-                </p>
+                <div>
+                  <h1 className="text-4xl font-bold tracking-tight text-white sm:text-5xl lg:text-6xl">
+                    James{' '}
+                    <span className="gradient-text">De Raja</span>
+                  </h1>
+                  <p className="mt-3 text-xl font-semibold text-white/90 sm:text-2xl">
+                    Senior Real-Time Performance Engineer
+                  </p>
+                  <p className="mt-1.5 font-mono text-sm text-neon/80">
+                    Unity Rendering&nbsp;&bull;&nbsp;XR Frame Budgets&nbsp;&bull;&nbsp;CPU/GPU Bottleneck Isolation
+                  </p>
+                </div>
               </div>
 
               {/* Value prop */}

--- a/src/sections/HeroBentoSection.tsx
+++ b/src/sections/HeroBentoSection.tsx
@@ -76,13 +76,13 @@ export default function HeroBentoSection() {
               </div>
 
               {/* Identity + title */}
-              <div className="flex items-end gap-4 sm:gap-6">
+              <div className="flex items-start gap-4 sm:gap-5">
                 <div className="relative flex-shrink-0">
-                  <div className="absolute -inset-2 rounded-[1.4rem] bg-neon/10 blur-xl" aria-hidden="true" />
+                  <div className="absolute -inset-1.5 rounded-xl bg-neon/10 blur-lg" aria-hidden="true" />
                   <img
                     src="/images/james.jpg"
                     alt="James De Raja"
-                    className="relative h-24 w-24 sm:h-32 sm:w-32 lg:h-40 lg:w-40 rounded-[1.4rem] object-cover ring-1 ring-neon/25 shadow-[0_0_24px_rgba(129,140,248,0.22)]"
+                    className="relative h-20 w-20 sm:h-24 sm:w-24 lg:h-24 lg:w-24 rounded-xl object-cover ring-1 ring-neon/25 shadow-[0_0_20px_rgba(129,140,248,0.2)]"
                   />
                 </div>
                 <div>

--- a/src/sections/HeroBentoSection.tsx
+++ b/src/sections/HeroBentoSection.tsx
@@ -76,13 +76,13 @@ export default function HeroBentoSection() {
               </div>
 
               {/* Identity + title */}
-              <div className="flex items-start gap-4 sm:gap-5">
-                <div className="relative mt-1 flex-shrink-0">
-                  <div className="absolute -inset-2 rounded-2xl bg-neon/10 blur-xl" aria-hidden="true" />
+              <div className="flex items-end gap-4 sm:gap-6">
+                <div className="relative flex-shrink-0">
+                  <div className="absolute -inset-2 rounded-[1.4rem] bg-neon/10 blur-xl" aria-hidden="true" />
                   <img
                     src="/images/james.jpg"
                     alt="James De Raja"
-                    className="relative h-20 w-20 sm:h-24 sm:w-24 lg:h-28 lg:w-28 rounded-2xl object-cover ring-1 ring-neon/25 shadow-[0_0_24px_rgba(129,140,248,0.22)]"
+                    className="relative h-24 w-24 sm:h-32 sm:w-32 lg:h-40 lg:w-40 rounded-[1.4rem] object-cover ring-1 ring-neon/25 shadow-[0_0_24px_rgba(129,140,248,0.22)]"
                   />
                 </div>
                 <div>


### PR DESCRIPTION
### Motivation
- Introduce light theme variants for the particle background so the canvas visuals match the site's light/dark modes.
- Improve global selection styling to use theme-aware CSS variables and better handle link selection.
- Polish the hero area visuals and layout to present the identity block and avatar more prominently and consistently.

### Description
- `src/components/ParticleField.tsx`: added a `theme` prop and switched particle hue, opacity, connection line lightness/alpha, and canvas opacity based on `theme`, and wired the effect hook to re-run on `theme` changes.
- `src/pages/HomePage.tsx`: imported `useTheme` and passed the current `theme` into `ParticleField`.
- `src/index.css`: added `--selection-*` CSS variables and updated `::selection` rules to use those variables with stronger selection styling for links.
- `src/sections/HeroBentoSection.tsx`: reorganized the top of the hero card to separate the availability badge from the identity block, increased avatar sizing and shadow/ring styling, and adjusted surrounding markup for consistent spacing.
- `src/sections/ContactBentoSection.tsx`: small text class cleanup on resume links to unify hover styling.

### Testing
- Ran type checking with `tsc --noEmit`, which completed successfully.
- Built the app with `yarn build`, and the production build succeeded without errors.
- Executed the test suite with `yarn test`, and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eef097103883249a75981b91b4cc80)