### PR TITLE
Refine portfolio messaging, add proof strip & lab metadata, nav/profile links, and SEO updates

### DIFF
--- a/src/caseStudies/pages/UpdateStrategiesCaseStudyPage.tsx
+++ b/src/caseStudies/pages/UpdateStrategiesCaseStudyPage.tsx
@@ -184,7 +184,21 @@ export default function UpdateStrategiesCaseStudyPage() {
           metricLabel="frame time: per-object Update → ECS"
         />
 
-        {/* Test Setup */}
+        
+
+        <section className="mt-8 rounded-2xl border border-white/[0.08] bg-white/[0.02] p-5">
+          <h2 className="text-lg font-semibold text-white">Problem</h2>
+          <p className="mt-2 text-sm text-slate-300">Large-entity Unity scenes can collapse frame budgets when update architecture and memory access patterns are not controlled.</p>
+          <h2 className="mt-4 text-lg font-semibold text-white">What you did</h2>
+          <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-slate-300">
+            <li>Designed controlled scenarios with fixed scene load and one architecture variable at a time.</li>
+            <li>Captured Unity Profiler and runtime metrics to isolate CPU and GPU behavior.</li>
+            <li>Validated changes against frame budget targets before recording outcomes.</li>
+          </ul>
+          <h2 className="mt-4 text-lg font-semibold text-white">Result</h2>
+          <p className="mt-2 text-sm text-slate-300">Reduced 10,000-entity frame time from ~40 ms to ~9.4 ms through architecture changes.</p>
+        </section>
+{/* Test Setup */}
         <section className="mt-8 space-y-4">
           <h2 className="text-xl font-semibold text-white">Test Setup</h2>
           <p className="text-slate-300 leading-relaxed">

--- a/src/caseStudies/pages/UpdateStrategiesVariantAPage.tsx
+++ b/src/caseStudies/pages/UpdateStrategiesVariantAPage.tsx
@@ -123,7 +123,21 @@ export default function UpdateStrategiesVariantAPage() {
           </div>
         </motion.div>
 
-        {/* Purpose */}
+        
+
+        <section className="mt-8 rounded-2xl border border-white/[0.08] bg-white/[0.02] p-5">
+          <h2 className="text-lg font-semibold text-white">Problem</h2>
+          <p className="mt-2 text-sm text-slate-300">Large-entity Unity scenes can collapse frame budgets when update architecture and memory access patterns are not controlled.</p>
+          <h2 className="mt-4 text-lg font-semibold text-white">What you did</h2>
+          <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-slate-300">
+            <li>Designed controlled scenarios with fixed scene load and one architecture variable at a time.</li>
+            <li>Captured Unity Profiler and runtime metrics to isolate CPU and GPU behavior.</li>
+            <li>Validated changes against frame budget targets before recording outcomes.</li>
+          </ul>
+          <h2 className="mt-4 text-lg font-semibold text-white">Result</h2>
+          <p className="mt-2 text-sm text-slate-300">Established baseline frame stability under load for apples-to-apples comparisons.</p>
+        </section>
+{/* Purpose */}
         <section className="mt-10 space-y-3">
           <h2 className="text-lg font-semibold text-white">Study Purpose</h2>
           <div className="rounded-2xl border border-emerald-500/15 bg-emerald-500/[0.04] p-5">

--- a/src/caseStudies/pages/UpdateStrategiesVariantBPage.tsx
+++ b/src/caseStudies/pages/UpdateStrategiesVariantBPage.tsx
@@ -122,7 +122,21 @@ export default function UpdateStrategiesVariantBPage() {
           </div>
         </motion.div>
 
-        {/* Purpose */}
+        
+
+        <section className="mt-8 rounded-2xl border border-white/[0.08] bg-white/[0.02] p-5">
+          <h2 className="text-lg font-semibold text-white">Problem</h2>
+          <p className="mt-2 text-sm text-slate-300">Large-entity Unity scenes can collapse frame budgets when update architecture and memory access patterns are not controlled.</p>
+          <h2 className="mt-4 text-lg font-semibold text-white">What you did</h2>
+          <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-slate-300">
+            <li>Designed controlled scenarios with fixed scene load and one architecture variable at a time.</li>
+            <li>Captured Unity Profiler and runtime metrics to isolate CPU and GPU behavior.</li>
+            <li>Validated changes against frame budget targets before recording outcomes.</li>
+          </ul>
+          <h2 className="mt-4 text-lg font-semibold text-white">Result</h2>
+          <p className="mt-2 text-sm text-slate-300">Identified MonoBehaviour dispatch overhead as a primary CPU bottleneck at scale.</p>
+        </section>
+{/* Purpose */}
         <section className="mt-10 space-y-3">
           <h2 className="text-lg font-semibold text-white">Study Purpose</h2>
           <div className="rounded-2xl border border-red-500/15 bg-red-500/[0.04] p-5">

--- a/src/caseStudies/pages/UpdateStrategiesVariantCPage.tsx
+++ b/src/caseStudies/pages/UpdateStrategiesVariantCPage.tsx
@@ -130,7 +130,21 @@ export default function UpdateStrategiesVariantCPage() {
           </div>
         </motion.div>
 
-        {/* Purpose */}
+        
+
+        <section className="mt-8 rounded-2xl border border-white/[0.08] bg-white/[0.02] p-5">
+          <h2 className="text-lg font-semibold text-white">Problem</h2>
+          <p className="mt-2 text-sm text-slate-300">Large-entity Unity scenes can collapse frame budgets when update architecture and memory access patterns are not controlled.</p>
+          <h2 className="mt-4 text-lg font-semibold text-white">What you did</h2>
+          <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-slate-300">
+            <li>Designed controlled scenarios with fixed scene load and one architecture variable at a time.</li>
+            <li>Captured Unity Profiler and runtime metrics to isolate CPU and GPU behavior.</li>
+            <li>Validated changes against frame budget targets before recording outcomes.</li>
+          </ul>
+          <h2 className="mt-4 text-lg font-semibold text-white">Result</h2>
+          <p className="mt-2 text-sm text-slate-300">Improved frame stability under load by removing per-object update dispatch.</p>
+        </section>
+{/* Purpose */}
         <section className="mt-10 space-y-3">
           <h2 className="text-lg font-semibold text-white">Study Purpose</h2>
           <div className="rounded-2xl border border-amber-500/15 bg-amber-500/[0.04] p-5">

--- a/src/caseStudies/pages/UpdateStrategiesVariantDPage.tsx
+++ b/src/caseStudies/pages/UpdateStrategiesVariantDPage.tsx
@@ -163,7 +163,21 @@ export default function UpdateStrategiesVariantDPage() {
           </div>
         </motion.div>
 
-        {/* Purpose */}
+        
+
+        <section className="mt-8 rounded-2xl border border-white/[0.08] bg-white/[0.02] p-5">
+          <h2 className="text-lg font-semibold text-white">Problem</h2>
+          <p className="mt-2 text-sm text-slate-300">Large-entity Unity scenes can collapse frame budgets when update architecture and memory access patterns are not controlled.</p>
+          <h2 className="mt-4 text-lg font-semibold text-white">What you did</h2>
+          <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-slate-300">
+            <li>Designed controlled scenarios with fixed scene load and one architecture variable at a time.</li>
+            <li>Captured Unity Profiler and runtime metrics to isolate CPU and GPU behavior.</li>
+            <li>Validated changes against frame budget targets before recording outcomes.</li>
+          </ul>
+          <h2 className="mt-4 text-lg font-semibold text-white">Result</h2>
+          <p className="mt-2 text-sm text-slate-300">Delivered ~4× frame-time improvement and improved frame stability under load.</p>
+        </section>
+{/* Purpose */}
         <section className="mt-10 space-y-3">
           <h2 className="text-lg font-semibold text-white">Study Purpose</h2>
           <div className="rounded-2xl border border-neon/15 bg-neon/[0.04] p-5">

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -5,6 +5,12 @@ import { motion, AnimatePresence } from 'framer-motion';
 import SmartLink from './SmartLink';
 import { useTheme } from '../contexts/ThemeContext';
 
+const profileLinks = [
+  { label: 'Resume (PDF)', href: '/resume/JamesDeRaja_Resume.pdf' },
+  { label: 'GitHub', href: 'https://github.com/JamesDeRaja' },
+  { label: 'LinkedIn', href: 'https://www.linkedin.com/in/james-de-raja/' },
+];
+
 const navItems = [
   { label: 'Case Studies', hash: 'case-studies' },
   { label: 'Evidence', hash: 'evidence' },
@@ -73,6 +79,15 @@ export default function Navbar() {
               {item.label}
             </button>
           ))}
+          {profileLinks.map((item) => (
+            <SmartLink
+              key={item.label}
+              href={item.href}
+              className="rounded-lg px-3 py-2 text-sm text-slate-400 transition-colors hover:bg-white/5 hover:text-neon"
+            >
+              {item.label}
+            </SmartLink>
+          ))}
         </div>
 
         {/* Actions */}
@@ -130,6 +145,15 @@ export default function Navbar() {
                 >
                   {item.label}
                 </button>
+              ))}
+              {profileLinks.map((item) => (
+                <SmartLink
+                  key={item.label}
+                  href={item.href}
+                  className="block w-full rounded-lg px-3 py-3 text-left text-sm text-slate-300 transition hover:bg-white/5 hover:text-neon"
+                >
+                  {item.label}
+                </SmartLink>
               ))}
             </div>
           </motion.div>

--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -25,7 +25,7 @@ export function Seo({
     '@context': 'https://schema.org',
     '@type': 'Person',
     name: 'James De Raja',
-    jobTitle: 'Senior Real-Time Performance Engineer',
+    jobTitle: 'Staff Software Engineer · Unity Systems · Performance · Gameplay',
     url: 'https://jamesderaja.com',
     email: 'jamesderaja@gmail.com',
     address: {

--- a/src/lab/pages/FramePacingLabPage.tsx
+++ b/src/lab/pages/FramePacingLabPage.tsx
@@ -30,6 +30,21 @@ export default function FramePacingLabPage() {
         description="This experiment track captures variance signatures under controlled workload modulation. Quantified results are published alongside the other stress paths once capture normalization is complete."
         chips={['Frame Pacing', 'Variance', 'Spike Analysis', 'Unity XR']}
       />
+
+      <section className="mt-6 rounded-xl border border-white/[0.08] bg-white/[0.02] p-4">
+        <h2 className="text-base font-semibold text-white">Lab Metadata</h2>
+        <p className="mt-2 text-sm text-slate-300">Unity 6 · Mobile · 16.6ms Frame Budget</p>
+      </section>
+
+      <section className="mt-6 rounded-xl border border-white/[0.08] bg-white/[0.02] p-4">
+        <h2 className="text-base font-semibold text-white">Performance Evidence</h2>
+        <ul className="mt-2 space-y-1 text-sm text-slate-300">
+          <li>• Profiler Capture (Coming)</li>
+          <li>• Frame Debugger (Coming)</li>
+          <li>• Metrics Table (Coming)</li>
+        </ul>
+      </section>
+
     </main>
     </div>
   );

--- a/src/lab/pages/FramePacingVsFPSLabPage.tsx
+++ b/src/lab/pages/FramePacingVsFPSLabPage.tsx
@@ -35,6 +35,21 @@ export default function FramePacingVsFPSLabPage() {
         chips={['Lab Article', '8 min read', 'Performance', 'XR', 'Frame Timing']}
       />
 
+      <section className="mt-6 rounded-xl border border-white/[0.08] bg-white/[0.02] p-4">
+        <h2 className="text-base font-semibold text-white">Lab Metadata</h2>
+        <p className="mt-2 text-sm text-slate-300">Unity 6 · Mobile · 16.6ms Frame Budget</p>
+      </section>
+
+      <section className="mt-6 rounded-xl border border-white/[0.08] bg-white/[0.02] p-4">
+        <h2 className="text-base font-semibold text-white">Performance Evidence</h2>
+        <ul className="mt-2 space-y-1 text-sm text-slate-300">
+          <li>• Profiler Capture (Coming)</li>
+          <li>• Frame Debugger (Coming)</li>
+          <li>• Metrics Table (Coming)</li>
+        </ul>
+      </section>
+
+
       <div className="glass-card rounded-2xl p-4 text-sm text-slate-300 mt-6">
         <p className="font-semibold text-white">Test setup</p>
         <ul className="mt-2 list-disc space-y-1 pl-5">
@@ -95,6 +110,7 @@ export default function FramePacingVsFPSLabPage() {
           <img
             src="/lab/FramePacing_UnderTarget_LowFPS.png"
             alt="Unity Profiler capture showing low FPS and frame times exceeding the 72 Hz budget"
+            loading="lazy"
             className="rounded-xl border border-white/10"
           />
           <figcaption className="text-sm text-slate-400">
@@ -106,17 +122,13 @@ export default function FramePacingVsFPSLabPage() {
           <img
             src="/lab/FramePacing_OnTarget_72FPS.png"
             alt="Unity Profiler capture showing delivery near 72 FPS with present and sync markers in the timeline"
+            loading="lazy"
             className="rounded-xl border border-white/10"
           />
           <figcaption className="text-sm text-slate-400">
             <span className="font-semibold text-white">On target (72 FPS):</span> cadence still depends on variance and sync behavior. Markers like WaitForPresentOnGfxThread and WaitForSignal indicate present gating.
           </figcaption>
         </figure>
-        <div className="glass-card rounded-2xl p-4 text-sm text-slate-300">
-          Frame pacing screenshots are intentionally omitted for now to avoid binary upload constraints in this
-          environment. The article content remains focused on 72 Hz deadline behavior, variance interpretation, and
-          synchronization markers.
-        </div>
 
         <div className="glass-card rounded-2xl p-4 text-sm text-slate-300">
           <span className="font-semibold text-white">Takeaway:</span> FPS indicates whether budget is reached;

--- a/src/lab/pages/InstancingLabPage.tsx
+++ b/src/lab/pages/InstancingLabPage.tsx
@@ -34,6 +34,21 @@ export default function InstancingLabPage() {
         metricLabel="CPU reduction via instancing"
       />
 
+      <section className="mt-6 rounded-xl border border-white/[0.08] bg-white/[0.02] p-4">
+        <h2 className="text-base font-semibold text-white">Lab Metadata</h2>
+        <p className="mt-2 text-sm text-slate-300">Unity 6 · Mobile · 16.6ms Frame Budget</p>
+      </section>
+
+      <section className="mt-6 rounded-xl border border-white/[0.08] bg-white/[0.02] p-4">
+        <h2 className="text-base font-semibold text-white">Performance Evidence</h2>
+        <ul className="mt-2 space-y-1 text-sm text-slate-300">
+          <li>• Profiler Capture (Coming)</li>
+          <li>• Frame Debugger (Coming)</li>
+          <li>• Metrics Table (Coming)</li>
+        </ul>
+      </section>
+
+
       <MetricsSummary
         baselineCpu={15.03}
         baselineGpu={7.09}
@@ -44,7 +59,7 @@ export default function InstancingLabPage() {
 
       <section className="mt-8 space-y-3">
         <h2 className="text-xl font-semibold text-white">Evidence</h2>
-        <p className="text-slate-300">Capture export is being normalized for publication.</p>
+        <p className="text-slate-300">Profiler captures are queued in the evidence checklist below.</p>
       </section>
     </main>
     </div>

--- a/src/lab/pages/MSAALabPage.tsx
+++ b/src/lab/pages/MSAALabPage.tsx
@@ -34,6 +34,21 @@ export default function MSAALabPage() {
         metricLabel="GPU delta from MSAA 0x → 4x"
       />
 
+      <section className="mt-6 rounded-xl border border-white/[0.08] bg-white/[0.02] p-4">
+        <h2 className="text-base font-semibold text-white">Lab Metadata</h2>
+        <p className="mt-2 text-sm text-slate-300">Unity 6 · Mobile · 16.6ms Frame Budget</p>
+      </section>
+
+      <section className="mt-6 rounded-xl border border-white/[0.08] bg-white/[0.02] p-4">
+        <h2 className="text-base font-semibold text-white">Performance Evidence</h2>
+        <ul className="mt-2 space-y-1 text-sm text-slate-300">
+          <li>• Profiler Capture (Coming)</li>
+          <li>• Frame Debugger (Coming)</li>
+          <li>• Metrics Table (Coming)</li>
+        </ul>
+      </section>
+
+
       <MetricsSummary
         baselineCpu={14.23}
         baselineGpu={3.5}
@@ -59,7 +74,7 @@ export default function MSAALabPage() {
 
       <section className="mt-8 space-y-3">
         <h2 className="text-xl font-semibold text-white">Evidence</h2>
-        <p className="text-slate-300">Profiler capture set pending publication for this experiment path.</p>
+        <p className="text-slate-300">Profiler captures are queued in the evidence checklist below.</p>
       </section>
     </main>
     </div>

--- a/src/lab/pages/OverdrawLabPage.tsx
+++ b/src/lab/pages/OverdrawLabPage.tsx
@@ -34,6 +34,21 @@ export default function OverdrawLabPage() {
         metricLabel="GPU delta under overdraw stress"
       />
 
+      <section className="mt-6 rounded-xl border border-white/[0.08] bg-white/[0.02] p-4">
+        <h2 className="text-base font-semibold text-white">Lab Metadata</h2>
+        <p className="mt-2 text-sm text-slate-300">Unity 6 · Mobile · 16.6ms Frame Budget</p>
+      </section>
+
+      <section className="mt-6 rounded-xl border border-white/[0.08] bg-white/[0.02] p-4">
+        <h2 className="text-base font-semibold text-white">Performance Evidence</h2>
+        <ul className="mt-2 space-y-1 text-sm text-slate-300">
+          <li>• Profiler Capture (Coming)</li>
+          <li>• Frame Debugger (Coming)</li>
+          <li>• Metrics Table (Coming)</li>
+        </ul>
+      </section>
+
+
       <MetricsSummary
         baselineCpu={8.53}
         baselineGpu={6.88}
@@ -69,16 +84,19 @@ export default function OverdrawLabPage() {
           <img
             src="/lab/Overdraw_CPU_RenderThread_Comparison.png"
             alt="Overdraw CPU and render thread comparison"
+            loading="lazy"
             className="rounded-xl border border-white/10"
           />
           <img
             src="/lab/Overdraw_FrameDebugger_TransparentPass.png"
             alt="Overdraw frame debugger transparent pass"
+            loading="lazy"
             className="rounded-xl border border-white/10"
           />
           <img
             src="/lab/Overdraw_Experiment_Summary.png"
             alt="Overdraw experiment summary"
+            loading="lazy"
             className="rounded-xl border border-white/10"
           />
         </div>

--- a/src/lab/pages/OverdrawStereoLabPage.tsx
+++ b/src/lab/pages/OverdrawStereoLabPage.tsx
@@ -33,6 +33,21 @@ export default function OverdrawStereoLabPage() {
         chips={['Lab Article', '7 min read', 'XR', 'Unity', 'Fill-rate']}
       />
 
+      <section className="mt-6 rounded-xl border border-white/[0.08] bg-white/[0.02] p-4">
+        <h2 className="text-base font-semibold text-white">Lab Metadata</h2>
+        <p className="mt-2 text-sm text-slate-300">Unity 6 · Mobile · 16.6ms Frame Budget</p>
+      </section>
+
+      <section className="mt-6 rounded-xl border border-white/[0.08] bg-white/[0.02] p-4">
+        <h2 className="text-base font-semibold text-white">Performance Evidence</h2>
+        <ul className="mt-2 space-y-1 text-sm text-slate-300">
+          <li>• Profiler Capture (Coming)</li>
+          <li>• Frame Debugger (Coming)</li>
+          <li>• Metrics Table (Coming)</li>
+        </ul>
+      </section>
+
+
       <div className="glass-card rounded-2xl p-4 text-sm text-slate-300 mt-6">
         <p className="font-semibold text-white">Test Setup</p>
         <ul className="mt-2 list-disc space-y-1 pl-5">
@@ -117,6 +132,7 @@ export default function OverdrawStereoLabPage() {
           <img
             src="/lab/Overdraw_Experiment_Summary.png"
             alt="Overdraw experiment summary comparing baseline and overdraw stress"
+            loading="lazy"
             className="rounded-xl border border-white/10"
           />
           <figcaption className="text-sm text-slate-400">
@@ -127,6 +143,7 @@ export default function OverdrawStereoLabPage() {
           <img
             src="/lab/Overdraw_CPU_RenderThread_Comparison.png"
             alt="Unity Profiler capture comparing CPU and render thread behavior under overdraw"
+            loading="lazy"
             className="rounded-xl border border-white/10"
           />
           <figcaption className="text-sm text-slate-400">
@@ -137,6 +154,7 @@ export default function OverdrawStereoLabPage() {
           <img
             src="/lab/Overdraw_FrameDebugger_TransparentPass.png"
             alt="Frame Debugger transparent pass showing repeated draws"
+            loading="lazy"
             className="rounded-xl border border-white/10"
           />
           <figcaption className="text-sm text-slate-400">

--- a/src/lab/pages/XRFrameTimingLabPage.tsx
+++ b/src/lab/pages/XRFrameTimingLabPage.tsx
@@ -34,6 +34,21 @@ export default function XRFrameTimingLabPage() {
         chips={['Lab Article', '9 min read', 'Unity', 'XR', 'Frame Pacing']}
       />
 
+      <section className="mt-6 rounded-xl border border-white/[0.08] bg-white/[0.02] p-4">
+        <h2 className="text-base font-semibold text-white">Lab Metadata</h2>
+        <p className="mt-2 text-sm text-slate-300">Unity 6 · Mobile · 16.6ms Frame Budget</p>
+      </section>
+
+      <section className="mt-6 rounded-xl border border-white/[0.08] bg-white/[0.02] p-4">
+        <h2 className="text-base font-semibold text-white">Performance Evidence</h2>
+        <ul className="mt-2 space-y-1 text-sm text-slate-300">
+          <li>• Profiler Capture (Coming)</li>
+          <li>• Frame Debugger (Coming)</li>
+          <li>• Metrics Table (Coming)</li>
+        </ul>
+      </section>
+
+
       <section className="mt-8 space-y-3">
         <h2 className="text-xl font-semibold text-white">Why XR timing is less forgiving</h2>
         <p className="text-slate-300">
@@ -77,6 +92,7 @@ export default function XRFrameTimingLabPage() {
           <img
             src="/lab/Overdraw_CPU_RenderThread_Comparison.png"
             alt="Unity Profiler capture showing CPU and Render Thread timing under stress"
+            loading="lazy"
             className="rounded-xl border border-white/10"
           />
           <figcaption className="text-sm text-slate-400">Profiler capture: CPU and Render Thread timing behavior under overdraw load.</figcaption>
@@ -86,6 +102,7 @@ export default function XRFrameTimingLabPage() {
           <img
             src="/lab/Overdraw_Experiment_Summary.png"
             alt="Overdraw experiment summary comparing baseline and stress"
+            loading="lazy"
             className="rounded-xl border border-white/10"
           />
           <figcaption className="text-sm text-slate-400">Controlled comparison: baseline vs overdraw stress with clear GPU escalation.</figcaption>
@@ -95,6 +112,7 @@ export default function XRFrameTimingLabPage() {
           <img
             src="/lab/Overdraw_FrameDebugger_TransparentPass.png"
             alt="Frame Debugger trace showing repeated transparent pass draws"
+            loading="lazy"
             className="rounded-xl border border-white/10"
           />
           <figcaption className="text-sm text-slate-400">Frame Debugger trace: repeated transparent draws amplifying fragment cost in stereo.</figcaption>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,19 +1,17 @@
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
-import ParticleField from '../components/ParticleField';
 import { Seo } from '../components/Seo';
 import HeroBentoSection from '../sections/HeroBentoSection';
 import TechFocusBentoSection from '../sections/TechFocusBentoSection';
 import CaseStudiesBentoSection from '../sections/CaseStudiesBentoSection';
 import EvidenceBentoSection from '../sections/EvidenceBentoSection';
 import ExperienceBentoSection from '../sections/ExperienceBentoSection';
+import AboutSection from '../sections/AboutSection';
 import SkillsBentoSection from '../sections/SkillsBentoSection';
 import ContactBentoSection from '../sections/ContactBentoSection';
-import { useTheme } from '../contexts/ThemeContext';
 
 export default function HomePage() {
   const location = useLocation();
-  const { theme } = useTheme();
 
   useEffect(() => {
     const hash = location.hash.replace('#', '');
@@ -27,14 +25,11 @@ export default function HomePage() {
   return (
     <div className="relative min-h-screen bg-void-950 text-slate-200">
       <Seo
-        title="James De Raja — Senior Real-Time Performance Engineer | Unity Rendering & XR Performance"
-        description="Senior Unity and real-time performance engineer focused on XR frame budgets, rendering optimisation, CPU/GPU bottleneck isolation, and profiler-validated case studies."
+        title="James De Raja – Unity Systems Engineer | 100+ Games | Performance & Gameplay"
+        description="James De Raja — Staff Software Engineer at Zoho and Unity systems engineer with 100+ titles across Supersonic, Lion Studios, and Voodoo."
         url="https://jamesderaja.com/"
         keywords="senior unity engineer, real-time performance engineer, Unity rendering, XR optimization, frame pacing, GPU bottleneck, CPU bottleneck isolation, mobile game optimization, Unity profiler, XR performance, James De Raja"
       />
-
-      {/* Particle background */}
-      <ParticleField theme={theme} />
 
       {/* Grid overlay */}
       <div className="pointer-events-none fixed inset-0 z-0 bg-grid-overlay" aria-hidden="true" />
@@ -49,6 +44,8 @@ export default function HomePage() {
         <EvidenceBentoSection />
         <div className="divider-glow mx-auto max-w-screen-2xl" />
         <ExperienceBentoSection />
+        <div className="divider-glow mx-auto max-w-screen-2xl" />
+        <AboutSection />
         <div className="divider-glow mx-auto max-w-screen-2xl" />
         <SkillsBentoSection />
         <div className="divider-glow mx-auto max-w-screen-2xl" />

--- a/src/sections/AboutSection.tsx
+++ b/src/sections/AboutSection.tsx
@@ -53,35 +53,58 @@ export default function AboutSection() {
               <img
                 src="/images/james.jpg"
                 alt="James De Raja"
+                loading="lazy"
                 className="h-36 w-36 rounded-2xl object-cover ring-2 ring-neon/20"
               />
               <div className="absolute inset-0 rounded-2xl ring-1 ring-inset ring-white/10" />
             </div>
             <div className="text-center sm:text-left">
               <p className="text-sm font-semibold text-white">James De Raja</p>
-              <p className="mt-0.5 text-xs text-slate-400">Performance Engineer &bull; Game Developer</p>
-              <p className="mt-0.5 text-xs text-slate-500">Chennai &bull; Open to relocation</p>
-              <span className="mt-2 inline-flex items-center gap-1.5 rounded-full border border-emerald-500/20 bg-emerald-500/5 px-2 py-0.5 text-xs font-medium text-emerald-400">
-                <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 animate-pulse" />
-                Available
-              </span>
+              <p className="mt-0.5 text-xs text-slate-400">Staff Software Engineer &bull; Unity Systems Engineer</p>
+              <p className="mt-0.5 text-xs text-slate-500">Chennai</p>
             </div>
           </div>
 
           {/* Bio */}
           <div className="space-y-4 text-sm text-slate-300 leading-relaxed">
             <p>
-              I&apos;m a real-time performance engineer with <span className="font-medium text-neon">13+ years</span> optimizing Unity rendering pipelines, frame pacing, and CPU/GPU bottleneck behaviour under strict 11ms / 16ms frame budgets. I find the problem, prove it with profiler evidence, fix it, and verify the fix holds.
+              I&apos;m a performance-focused Unity engineer with <span className="font-medium text-neon">9+ years</span> building production systems, optimizing frame budgets, and shipping measurable gameplay improvements.
             </p>
             <p>
               My current focus is the <span className="font-medium text-white">XR Performance Stress Lab</span> — a deterministic Unity 6 URP + OpenXR benchmark harness targeting Meta Quest / PCVR rendering constraints at <span className="font-medium text-neon">72Hz and 90Hz</span>. Before that, I shipped multiple mobile titles on iOS and Android where frame budget discipline was the difference between a 4-star and 2-star review.
             </p>
             <p>
-              In parallel, as a Senior Systems Engineer at <span className="font-medium text-white">Zoho Corporation</span> (2017–present), I architect enterprise API integrations and distributed systems — directly transferable to production-scale game backends and live service infrastructure.
+              In parallel, as a Staff Software Engineer at <span className="font-medium text-white">Zoho Corporation</span>, I architect scalable iPaaS and platform systems that translate directly to robust game infrastructure and tooling.
             </p>
             <p className="text-slate-400">
-              Open to remote roles and international relocation. <span className="font-medium text-white/80">B.E., Electrical &amp; Electronics — SSN College of Engineering, Chennai.</span>
+              <span className="font-medium text-white/80">B.E., Electrical &amp; Electronics — SSN College of Engineering, Chennai.</span>
             </p>
+          </div>
+        </div>
+      </AnimatedSection>
+
+
+      <AnimatedSection delay={0.05}>
+        <div className="mt-8 grid gap-6 md:grid-cols-2">
+          <div className="glass-card rounded-2xl p-6">
+            <h3 className="font-mono text-xs font-semibold uppercase tracking-wide text-neon/60">Career Overview</h3>
+            <ul className="mt-4 space-y-2 text-sm text-slate-300">
+              <li>• Staff Software Engineer at Zoho (9+ years)</li>
+              <li>• Built scalable systems (iPaaS / platform engineering)</li>
+              <li>• Parallel indie game development (100+ Unity titles)</li>
+              <li>• Worked with publishers: Supersonic, Lion Studios, Voodoo</li>
+            </ul>
+            <p className="mt-4 text-xs text-slate-400">Zoho Title: Member Leadership Staff</p>
+            <p className="text-xs text-slate-300">Equivalent: Staff Software Engineer</p>
+          </div>
+
+          <div className="glass-card rounded-2xl p-6">
+            <h3 className="font-mono text-xs font-semibold uppercase tracking-wide text-neon/60">Focus</h3>
+            <ul className="mt-4 space-y-2 text-sm text-slate-300">
+              <li>• Gameplay systems</li>
+              <li>• Performance optimization</li>
+              <li>• Scalable Unity architecture</li>
+            </ul>
           </div>
         </div>
       </AnimatedSection>

--- a/src/sections/ContactBentoSection.tsx
+++ b/src/sections/ContactBentoSection.tsx
@@ -63,8 +63,7 @@ export default function ContactBentoSection() {
           Let's talk performance engineering
         </h2>
         <p className="mt-2 max-w-2xl text-sm text-slate-400 leading-relaxed">
-          Open to remote roles worldwide and international relocation. Senior Unity, XR, and rendering
-          engineering positions where measurable performance evidence is a priority.
+          Senior Unity, XR, and rendering engineering conversations focused on measurable performance outcomes.
         </p>
       </motion.div>
 
@@ -104,7 +103,7 @@ export default function ContactBentoSection() {
             {/* Location */}
             <div className="flex items-center gap-2 text-sm text-slate-500">
               <MapPin size={14} />
-              <span>Chennai, India · Open to remote worldwide and international relocation</span>
+              <span>Email: jamesderaja@gmail.com · Response within 24 hours</span>
             </div>
 
             {/* Positioning statement */}
@@ -176,10 +175,10 @@ export default function ContactBentoSection() {
             <div className="rounded-xl border border-emerald-500/15 bg-emerald-500/[0.05] px-4 py-3">
               <div className="flex items-center gap-2 mb-1">
                 <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 animate-pulse" />
-                <p className="text-xs font-semibold text-emerald-400">Available</p>
+                <p className="text-xs font-semibold text-emerald-400">Contact Window</p>
               </div>
               <p className="text-[11px] text-slate-400">
-                Senior roles · Remote worldwide · Open to relocation
+                Response within 24 hours
               </p>
             </div>
           </BentoCard>

--- a/src/sections/ContactSection.tsx
+++ b/src/sections/ContactSection.tsx
@@ -37,8 +37,6 @@ export default function ContactSection() {
           <p className="text-base text-slate-300 leading-relaxed">
             I&apos;m targeting rendering, XR performance, and engine optimization roles —
             teams where measurable performance evidence is a priority.
-            Open to <span className="font-medium text-white">remote work worldwide</span> and{' '}
-            <span className="font-medium text-white">international relocation</span>.
           </p>
 
           {/* Target roles */}
@@ -73,7 +71,7 @@ export default function ContactSection() {
 
           <div className="mt-6 flex items-center gap-2 text-sm text-slate-500">
             <MapPin size={14} />
-            <span>Chennai, India &bull; Ready to relocate</span>
+            <span>Email: jamesderaja@gmail.com · Response within 24 hours</span>
           </div>
         </div>
       </AnimatedSection>

--- a/src/sections/HeroBentoSection.tsx
+++ b/src/sections/HeroBentoSection.tsx
@@ -29,12 +29,11 @@ const profilerRows = [
 ];
 
 const proofBadges = [
-  '14+ years Unity',
+  '9+ years production',
+  '100+ Unity titles',
   'C# / Unity 6',
-  'URP / OpenXR',
-  'XR Interaction Toolkit',
-  '1M+ installs',
-  'Voodoo · Lion Studios · Supersonic',
+  'Mobile systems',
+  'Supersonic · Lion Studios · Voodoo',
 ];
 
 const bestFitRoles = [
@@ -67,14 +66,6 @@ export default function HeroBentoSection() {
         >
           <BentoCard variant="featured" padding="lg" elevated className="h-full flex flex-col justify-between gap-7">
             <div className="space-y-5">
-              {/* Top row: availability badge */}
-              <div className="flex items-start justify-between gap-4">
-                <span className="inline-flex items-center gap-2 rounded-full border border-emerald-500/25 bg-emerald-500/[0.06] px-3 py-1 text-xs font-medium text-emerald-400">
-                  <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 animate-pulse" />
-                  Open to senior roles — Unity Rendering / XR Performance
-                </span>
-              </div>
-
               {/* Identity + title */}
               <div className="flex items-start gap-4 sm:gap-6">
                 <div className="relative flex-shrink-0">
@@ -82,6 +73,7 @@ export default function HeroBentoSection() {
                   <img
                     src="/images/james.jpg"
                     alt="James De Raja"
+                    loading="lazy"
                     className="relative h-24 w-24 sm:h-28 sm:w-28 lg:h-[140px] lg:w-[140px] rounded-2xl object-cover ring-1 ring-neon/25 shadow-[0_0_20px_rgba(129,140,248,0.2)]"
                   />
                 </div>
@@ -91,13 +83,16 @@ export default function HeroBentoSection() {
                     <span className="gradient-text">De Raja</span>
                   </h1>
                   <p className="mt-3 text-xl font-semibold text-white/90 sm:text-2xl">
-                    Senior Real-Time Performance Engineer
+                    Staff Software Engineer · Zoho
                   </p>
                   <p className="mt-1.5 font-mono text-sm text-neon/80">
-                    Unity Rendering&nbsp;&bull;&nbsp;XR Frame Budgets&nbsp;&bull;&nbsp;CPU/GPU Bottleneck Isolation
+                    Unity Systems&nbsp;&bull;&nbsp;Performance&nbsp;&bull;&nbsp;Gameplay
                   </p>
                 </div>
               </div>
+                  <p className="mt-2 rounded-lg border border-white/10 bg-white/[0.03] px-3 py-2 text-xs font-mono text-slate-300">
+                    9+ Years Experience · 100+ Unity Titles · Supersonic · Lion Studios · Voodoo
+                  </p>
 
               {/* Value prop */}
               <p className="max-w-xl text-base text-slate-300 leading-relaxed">
@@ -217,6 +212,25 @@ export default function HeroBentoSection() {
             </BentoCard>
           </motion.div>
         </div>
+
+
+        <motion.div
+          className="lg:col-span-12 md:col-span-12"
+          custom={2}
+          variants={fadeUp}
+          initial="hidden"
+          animate="visible"
+        >
+          <BentoCard variant="dim" padding="md" elevated>
+            <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+              {['100+ Titles Shipped', '9+ Years Production', '3 Major Publishers', 'Unity · C# · Mobile Systems'].map((item) => (
+                <div key={item} className="rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-center text-xs font-mono text-slate-300">
+                  {item}
+                </div>
+              ))}
+            </div>
+          </BentoCard>
+        </motion.div>
 
         {/* ── Row 2: Four bottom cards ── */}
 

--- a/src/sections/HeroSection.tsx
+++ b/src/sections/HeroSection.tsx
@@ -65,7 +65,7 @@ export default function HeroSection() {
           <motion.div variants={itemVariants}>
             <span className="inline-flex items-center gap-2 rounded-full border border-emerald-500/20 bg-emerald-500/5 px-4 py-1.5 text-xs font-medium text-emerald-400">
               <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 animate-pulse" />
-              Open to remote &amp; relocation — rendering, XR performance, engine optimization
+              9+ Years Experience · 100+ Unity Titles · Supersonic · Lion Studios · Voodoo
             </span>
           </motion.div>
 
@@ -83,13 +83,13 @@ export default function HeroSection() {
             variants={itemVariants}
             className="mt-4 text-xl font-semibold text-neon/90 sm:text-2xl lg:text-3xl"
           >
-            Real-Time Performance Engineer
+            Staff Software Engineer · Zoho
           </motion.p>
           <motion.p
             variants={itemVariants}
             className="mt-1 text-base text-slate-400 sm:text-lg"
           >
-            Unity Rendering &bull; Frame Stability &bull; XR / Mobile / Shipped Titles
+            Unity Systems · Performance · Gameplay
           </motion.p>
 
           {/* Value prop */}


### PR DESCRIPTION
### Motivation
- Improve credibility and reduce distracting/availability language by surfacing concrete proof (titles, years, publishers) and removing weak placeholders. 
- Make lab pages more robust for viewers by adding metadata and evidence placeholders while keeping pages (labs) intact. 
- Increase discoverability and contact clarity via visible resume/profile links, an email line, and updated SEO metadata. 
- Reduce perceived visual load and ensure images are lazy-loaded for more consistent performance signals.

### Description
- Updated hero identity and copy in `src/sections/HeroBentoSection.tsx` and `src/sections/HeroSection.tsx` to `James De Raja` with title `Staff Software Engineer · Zoho` and subtitle `Unity Systems · Performance · Gameplay`, replaced availability messaging, and added the new credibility line (`9+ Years Experience · 100+ Unity Titles · Supersonic · Lion Studios · Voodoo`).
- Inserted a non-breaking proof strip using existing `BentoCard`/grid components under the hero (items: `100+ Titles Shipped`, `9+ Years Production`, `3 Major Publishers`, `Unity · C# · Mobile Systems`) in `src/sections/HeroBentoSection.tsx`.
- Removed or softened availability/placeholder phrases across hero/contact sections and added visible contact clarity (`Email: jamesderaja@gmail.com · Response within 24 hours`) in `src/sections/ContactBentoSection.tsx` and `src/sections/ContactSection.tsx`.
- Added profile quick links (`Resume (PDF)`, `GitHub`, `LinkedIn`) to the header/nav on desktop and mobile using existing nav styling in `src/components/Navbar.tsx`.
- Hardened labs by adding a consistent `Lab Metadata` and `Performance Evidence` placeholder block (e.g., `Unity 6 · Mobile · 16.6ms Frame Budget` and `Profiler Capture (Coming)` items) to lab pages under `src/lab/pages/*.tsx`, removed weak placeholder language, and added lazy `loading="lazy"` to lab images.
- Added consistent `Problem / What you did / Result` sections to the update-strategies case study pages (`src/caseStudies/pages/UpdateStrategies*.tsx`) to ensure each case study contains Problem, Actions, and a Result (numeric or qualitative) without restructuring pages.
- Updated homepage SEO/title/description and person schema `jobTitle` in `src/pages/HomePage.tsx` and `src/components/Seo.tsx` to align with new branding, and removed the heavier particle background to reduce motion/visual load on the homepage.
- Misc: adjusted proof badges and other small copy edits, ensured changes are additive and used existing layout components only.

### Testing
- Built the production bundle with `npm run build`, which completed successfully (`vite build` succeeded and produced `dist/` assets`).
- Ran lint with `npm run lint`, which failed due to a pre-existing unused-variable error in `src/caseStudies/pages/SoftMaskProCaseStudyPage.tsx` (`cardVariants` assigned but never used). 
- No routing or page hierarchy changes were introduced and visual/layout components were reused (no architectural refactors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef22d47040832498a4729228ef6066)