### PR TITLE
Simplify resume section to single PDF actions

### DIFF
--- a/public/resume/viewer.html
+++ b/public/resume/viewer.html
@@ -25,16 +25,11 @@
   <body>
     <iframe id="resumeFrame" title="Resume PDF"></iframe>
     <script>
-      const allowedFiles = new Set([
-        'JamesDeRaja_Resume.pdf',
-        'JamesDeRaja_Resume_Performance-Systems.pdf',
-        'JamesDeRaja_Resume_Unity-Rendering-Performance.pdf',
-        'JamesDeRaja_Resume_XR-Performance-Engineer.pdf'
-      ]);
+      const allowedFiles = new Set(['James DeRaja Resume.pdf']);
 
       const params = new URLSearchParams(window.location.search);
-      const file = params.get('file') || 'JamesDeRaja_Resume.pdf';
-      const selectedFile = allowedFiles.has(file) ? file : 'JamesDeRaja_Resume.pdf';
+      const file = params.get('file') || 'James DeRaja Resume.pdf';
+      const selectedFile = allowedFiles.has(file) ? file : 'James DeRaja Resume.pdf';
 
       const resumeName = selectedFile.replace(/\.pdf$/i, '');
       document.title = resumeName;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,7 +9,7 @@ export default function Footer() {
           <SmartLink href="mailto:jamesderaja@gmail.com" className="transition hover:text-neon">Email</SmartLink>
           <SmartLink href="https://www.linkedin.com/in/james-de-raja/" className="transition hover:text-neon">LinkedIn</SmartLink>
           <SmartLink href="https://github.com/JamesDeRaja" className="transition hover:text-neon">GitHub</SmartLink>
-          <SmartLink href="/resume/viewer.html?file=JamesDeRaja_Resume.pdf" className="transition hover:text-neon">Resume</SmartLink>
+          <SmartLink href="/resume/viewer.html?file=James%20DeRaja%20Resume.pdf" className="transition hover:text-neon">Resume</SmartLink>
         </div>
       </div>
     </footer>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -78,13 +78,13 @@ export default function Navbar() {
         {/* Actions */}
         <div className="flex items-center gap-2">
           <SmartLink
-            href="/resume/viewer.html?file=JamesDeRaja_Resume.pdf"
+            href="/resume/viewer.html?file=James%20DeRaja%20Resume.pdf"
             className="btn-primary hidden rounded-lg px-4 py-2 text-sm font-medium sm:inline-flex"
           >
             View Resume
           </SmartLink>
           <a
-            href="/resume/JamesDeRaja_Resume.pdf"
+            href="/resume/James%20DeRaja%20Resume.pdf"
             download
             className="rounded-lg border border-white/10 p-2 text-slate-400 transition hover:border-neon/30 hover:text-neon"
             aria-label="Download resume PDF"

--- a/src/sections/ContactBentoSection.tsx
+++ b/src/sections/ContactBentoSection.tsx
@@ -34,6 +34,18 @@ const targetRoles = [
   'Technical Lead, Unity',
 ];
 
+const quickFitRows = [
+  '13+ years Unity / real-time systems',
+  'XR, rendering, ECS, multiplayer',
+  'Open to remote worldwide + relocation',
+];
+
+const proofLinks = [
+  { label: 'View Case Studies', href: '#case-studies' },
+  { label: 'View GitHub', href: 'https://github.com/JamesDeRaja' },
+  { label: 'View LinkedIn', href: 'https://www.linkedin.com/in/james-de-raja/' },
+];
+
 export default function ContactBentoSection() {
   return (
     <section id="contact" className="relative mx-auto max-w-screen-2xl px-4 py-20 pb-24 sm:px-6 lg:px-8">
@@ -71,7 +83,7 @@ export default function ContactBentoSection() {
           transition={{ duration: 0.5 }}
           viewport={{ once: true }}
         >
-          <BentoCard variant="featured" padding="lg" className="h-full flex flex-col gap-6">
+          <BentoCard variant="featured" padding="lg" className="h-full flex flex-col gap-5">
             {/* Contact links */}
             <div>
               <p className="font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500 mb-4">
@@ -101,28 +113,19 @@ export default function ContactBentoSection() {
               <span>Chennai, India · Open to remote worldwide and international relocation</span>
             </div>
 
-            {/* Positioning statement */}
+            {/* Target roles */}
             <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-4">
-              <p className="text-sm text-slate-300 leading-relaxed">
-                Targeting rendering, XR performance, and real-time systems engineering roles — teams
-                that prioritize frame budget discipline and profiler evidence as core engineering
-                requirements.
+              <p className="font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500">
+                Target Roles
               </p>
-              <div className="mt-3 flex flex-wrap gap-1.5">
-                {targetRoles.map((role) => (
-                  <span
-                    key={role}
-                    className="chip-glow rounded-full px-2.5 py-0.5 font-mono text-[11px]"
-                  >
-                    {role}
-                  </span>
-                ))}
-              </div>
+              <p className="mt-2 text-sm text-slate-300 leading-relaxed">
+                {targetRoles.join(' · ')}
+              </p>
             </div>
           </BentoCard>
         </motion.div>
 
-        {/* Resume card */}
+        {/* Recruiter packet card */}
         <motion.div
           className="lg:col-span-4 md:col-span-2"
           initial={{ opacity: 0, y: 16 }}
@@ -130,45 +133,81 @@ export default function ContactBentoSection() {
           transition={{ duration: 0.5, delay: 0.08 }}
           viewport={{ once: true }}
         >
-          <BentoCard variant="metric" padding="md" className="h-full flex flex-col gap-5">
+          <BentoCard variant="metric" padding="md" className="h-full flex flex-col gap-4 lg:gap-5 lg:px-6 lg:py-6">
             <div>
               <p className="font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500 mb-4">
-                Resume
+                Application Packet
               </p>
-              <div className="space-y-2.5">
+              <div className="space-y-3">
                 <a
                   href="/resume/James%20DeRaja%20Resume.pdf"
                   download
-                  className="group flex items-center justify-between gap-3 rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-3 hover:border-neon/25 hover:bg-neon/[0.04] transition-all duration-200"
+                  className="btn-primary group flex h-14 w-full items-center justify-center gap-2 rounded-xl px-4 text-sm font-medium"
                 >
-                  <div className="flex items-center gap-2.5">
-                    <FileText size={13} className="text-slate-500 group-hover:text-neon transition-colors" />
-                    <span className="text-xs text-slate-300 transition-colors">Download Resume</span>
-                  </div>
-                  <Download size={12} className="text-slate-600 group-hover:text-neon transition-colors flex-shrink-0" />
+                  <Download size={15} />
+                  Download Resume
                 </a>
+                <SmartLink
+                  href="/resume/viewer.html?file=James%20DeRaja%20Resume.pdf"
+                  className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-white/[0.08] bg-white/[0.02] px-4 py-3 text-sm font-medium text-indigo-300 transition-all hover:border-indigo-300/40 hover:text-indigo-200"
+                >
+                  <FileText size={14} />
+                  View Online
+                </SmartLink>
               </div>
             </div>
 
-            {/* Online resume */}
-            <div className="border-t border-white/[0.05] pt-4">
-              <SmartLink
-                href="/resume/viewer.html?file=James%20DeRaja%20Resume.pdf"
-                className="btn-primary flex items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-sm font-medium w-full"
-              >
-                <FileText size={14} />
-                View Online
-              </SmartLink>
+            {/* Quick fit summary */}
+            <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-3">
+              <p className="font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500">
+                Quick Fit
+              </p>
+              <div className="mt-2 space-y-1.5">
+                {quickFitRows.map((row) => (
+                  <p key={row} className="text-xs text-slate-300 leading-relaxed">
+                    {row}
+                  </p>
+                ))}
+              </div>
+            </div>
+
+            {/* Best fit */}
+            <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-3">
+              <p className="font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500">
+                Best Fit
+              </p>
+              <p className="mt-2 text-xs text-slate-300 leading-relaxed">
+                Rendering · XR Performance · Unity Systems · Technical Lead
+              </p>
+            </div>
+
+            {/* Proof links */}
+            <div>
+              <p className="font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500 mb-2.5">
+                Proof Links
+              </p>
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-3 md:grid-cols-1">
+                {proofLinks.map((link) => (
+                  <SmartLink
+                    key={link.label}
+                    href={link.href}
+                    className="inline-flex items-center justify-between rounded-lg border border-white/[0.08] bg-white/[0.02] px-3 py-2 text-xs text-indigo-300 transition-all hover:border-indigo-300/40 hover:text-indigo-200"
+                  >
+                    {link.label}
+                    <ArrowUpRight size={12} />
+                  </SmartLink>
+                ))}
+              </div>
             </div>
 
             {/* Availability status */}
-            <div className="rounded-xl border border-emerald-500/15 bg-emerald-500/[0.05] px-4 py-3">
-              <div className="flex items-center gap-2 mb-1">
+            <div className="rounded-xl border border-emerald-500/15 bg-emerald-500/[0.05] px-4 py-2.5">
+              <div className="mb-1 flex items-center gap-2">
                 <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 animate-pulse" />
                 <p className="text-xs font-semibold text-emerald-400">Available</p>
               </div>
               <p className="text-[11px] text-slate-400">
-                Senior roles · Remote worldwide · Open to relocation
+                Senior roles · Remote worldwide · Relocation open
               </p>
             </div>
           </BentoCard>

--- a/src/sections/ContactBentoSection.tsx
+++ b/src/sections/ContactBentoSection.tsx
@@ -130,39 +130,40 @@ export default function ContactBentoSection() {
           transition={{ duration: 0.5, delay: 0.08 }}
           viewport={{ once: true }}
         >
-          <BentoCard variant="metric" padding="md" className="h-full flex flex-col gap-4 lg:gap-4">
-            <div>
-              <p className="font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500 mb-4">
-                Application Packet
+          <BentoCard variant="metric" padding="md" className="h-full flex flex-col justify-center">
+            <div className="w-full">
+              <p className="font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500">
+                Get My Resume
               </p>
-              <div className="space-y-4">
+              <div className="mt-6 space-y-4">
                 <a
                   href="/resume/James%20DeRaja%20Resume.pdf"
                   download
-                  className="btn-primary group flex h-12 w-full items-center justify-center gap-2 rounded-xl px-4 text-sm font-medium"
+                  className="btn-primary group flex h-12 w-full items-center justify-center gap-2 rounded-xl px-4 text-sm font-semibold"
                 >
                   <Download size={15} />
                   Download Resume
                 </a>
                 <SmartLink
                   href="/resume/viewer.html?file=James%20DeRaja%20Resume.pdf"
-                  className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-white/[0.08] bg-white/[0.02] px-4 py-2.5 text-sm font-medium text-indigo-300 transition-all hover:border-indigo-300/40 hover:text-indigo-200"
+                  className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-xl border border-white/[0.12] bg-white/[0.02] px-4 text-sm font-medium text-indigo-300 transition-all hover:border-indigo-300/40 hover:text-indigo-200"
                 >
                   <FileText size={14} />
                   View Resume Online
                 </SmartLink>
               </div>
-            </div>
 
-            {/* Availability status */}
-            <div className="rounded-xl border border-emerald-500/15 bg-emerald-500/[0.05] px-4 py-2">
-              <div className="mb-1 flex items-center gap-2">
-                <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 animate-pulse" />
-                <p className="text-xs font-semibold text-emerald-400">Available</p>
+              {/* Availability status */}
+              <div className="mt-5 w-full rounded-xl border border-emerald-500/15 bg-emerald-500/[0.05] px-4 py-2">
+                <p className="mb-1 text-[11px] text-emerald-300/80">Available for senior roles</p>
+                <div className="mb-1 flex items-center gap-2">
+                  <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 animate-pulse" />
+                  <p className="text-xs font-semibold text-emerald-400">Available</p>
+                </div>
+                <p className="text-[11px] text-slate-400">
+                  Senior roles · Remote worldwide · Open to relocation
+                </p>
               </div>
-              <p className="text-[11px] text-slate-400">
-                Senior roles · Remote worldwide · Open to relocation
-              </p>
             </div>
           </BentoCard>
         </motion.div>

--- a/src/sections/ContactBentoSection.tsx
+++ b/src/sections/ContactBentoSection.tsx
@@ -71,7 +71,7 @@ export default function ContactBentoSection() {
       <BentoGrid>
         {/* Main contact card */}
         <motion.div
-          className="lg:col-span-7 md:col-span-4"
+          className="lg:col-span-8 md:col-span-4"
           initial={{ opacity: 0, y: 16 }}
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5 }}
@@ -148,29 +148,29 @@ export default function ContactBentoSection() {
 
         {/* Recruiter packet card */}
         <motion.div
-          className="lg:col-span-5 md:col-span-2"
+          className="lg:col-span-4 md:col-span-2"
           initial={{ opacity: 0, y: 16 }}
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5, delay: 0.08 }}
           viewport={{ once: true }}
         >
-          <BentoCard variant="metric" padding="md" className="flex flex-col gap-5 lg:px-7 lg:py-7">
+          <BentoCard variant="metric" padding="md" className="flex flex-col gap-4 lg:gap-4">
             <div>
               <p className="font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500 mb-4">
                 Application Packet
               </p>
-              <div className="space-y-5">
+              <div className="space-y-4">
                 <a
                   href="/resume/James%20DeRaja%20Resume.pdf"
                   download
-                  className="btn-primary group flex h-14 w-full items-center justify-center gap-2 rounded-xl px-4 text-sm font-medium"
+                  className="btn-primary group flex h-12 w-full items-center justify-center gap-2 rounded-xl px-4 text-sm font-medium"
                 >
                   <Download size={15} />
                   Download Resume
                 </a>
                 <SmartLink
                   href="/resume/viewer.html?file=James%20DeRaja%20Resume.pdf"
-                  className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-white/[0.08] bg-white/[0.02] px-4 py-3 text-sm font-medium text-indigo-300 transition-all hover:border-indigo-300/40 hover:text-indigo-200"
+                  className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-white/[0.08] bg-white/[0.02] px-4 py-2.5 text-sm font-medium text-indigo-300 transition-all hover:border-indigo-300/40 hover:text-indigo-200"
                 >
                   <FileText size={14} />
                   View Resume Online
@@ -179,7 +179,7 @@ export default function ContactBentoSection() {
             </div>
 
             {/* Availability status */}
-            <div className="rounded-xl border border-emerald-500/15 bg-emerald-500/[0.05] px-4 py-2.5 lg:mt-1">
+            <div className="rounded-xl border border-emerald-500/15 bg-emerald-500/[0.05] px-4 py-2">
               <div className="mb-1 flex items-center gap-2">
                 <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 animate-pulse" />
                 <p className="text-xs font-semibold text-emerald-400">Available</p>

--- a/src/sections/ContactBentoSection.tsx
+++ b/src/sections/ContactBentoSection.tsx
@@ -71,13 +71,13 @@ export default function ContactBentoSection() {
       <BentoGrid>
         {/* Main contact card */}
         <motion.div
-          className="lg:col-span-8 md:col-span-4"
+          className="lg:col-span-7 md:col-span-4"
           initial={{ opacity: 0, y: 16 }}
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5 }}
           viewport={{ once: true }}
         >
-          <BentoCard variant="featured" padding="lg" className="flex flex-col gap-5">
+          <BentoCard variant="featured" padding="lg" className="flex flex-col gap-5 lg:px-7 lg:py-7">
             {/* Contact links */}
             <div>
               <p className="font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500 mb-4">
@@ -124,23 +124,42 @@ export default function ContactBentoSection() {
                 ))}
               </div>
             </div>
+
+            {/* Proof links */}
+            <div className="border-t border-white/[0.08] pt-4">
+              <p className="mb-3 font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500">
+                Proof
+              </p>
+              <div className="flex flex-wrap gap-4">
+                {proofLinks.map((link) => (
+                  <SmartLink
+                    key={link.label}
+                    href={link.href}
+                    className="inline-flex items-center justify-between gap-2 rounded-lg border border-white/[0.08] bg-white/[0.02] px-3 py-2 text-xs text-indigo-300 transition-all hover:border-indigo-300/40 hover:text-indigo-200"
+                  >
+                    {link.label}
+                    <ArrowUpRight size={12} />
+                  </SmartLink>
+                ))}
+              </div>
+            </div>
           </BentoCard>
         </motion.div>
 
         {/* Recruiter packet card */}
         <motion.div
-          className="lg:col-span-4 md:col-span-2"
+          className="lg:col-span-5 md:col-span-2"
           initial={{ opacity: 0, y: 16 }}
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5, delay: 0.08 }}
           viewport={{ once: true }}
         >
-          <BentoCard variant="metric" padding="md" className="flex flex-col gap-4 lg:gap-4 lg:px-7 lg:py-7">
+          <BentoCard variant="metric" padding="md" className="flex flex-col gap-5 lg:px-7 lg:py-7">
             <div>
               <p className="font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500 mb-4">
                 Application Packet
               </p>
-              <div className="space-y-4">
+              <div className="space-y-5">
                 <a
                   href="/resume/James%20DeRaja%20Resume.pdf"
                   download
@@ -159,27 +178,8 @@ export default function ContactBentoSection() {
               </div>
             </div>
 
-            {/* Proof links */}
-            <div>
-              <p className="font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500 mb-2.5">
-                Proof Links
-              </p>
-              <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-3 md:grid-cols-1">
-                {proofLinks.map((link) => (
-                  <SmartLink
-                    key={link.label}
-                    href={link.href}
-                    className="inline-flex items-center justify-between rounded-lg border border-white/[0.08] bg-white/[0.02] px-3 py-2 text-xs text-indigo-300 transition-all hover:border-indigo-300/40 hover:text-indigo-200"
-                  >
-                    {link.label}
-                    <ArrowUpRight size={12} />
-                  </SmartLink>
-                ))}
-              </div>
-            </div>
-
             {/* Availability status */}
-            <div className="rounded-xl border border-emerald-500/15 bg-emerald-500/[0.05] px-4 py-2.5">
+            <div className="rounded-xl border border-emerald-500/15 bg-emerald-500/[0.05] px-4 py-2.5 lg:mt-1">
               <div className="mb-1 flex items-center gap-2">
                 <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 animate-pulse" />
                 <p className="text-xs font-semibold text-emerald-400">Available</p>

--- a/src/sections/ContactBentoSection.tsx
+++ b/src/sections/ContactBentoSection.tsx
@@ -34,12 +34,6 @@ const targetRoles = [
   'Technical Lead, Unity',
 ];
 
-const proofLinks = [
-  { label: 'View Case Studies', href: '#case-studies' },
-  { label: 'View GitHub', href: 'https://github.com/JamesDeRaja' },
-  { label: 'View LinkedIn', href: 'https://www.linkedin.com/in/james-de-raja/' },
-];
-
 export default function ContactBentoSection() {
   return (
     <section id="contact" className="relative mx-auto max-w-screen-2xl px-4 py-20 pb-24 sm:px-6 lg:px-8">
@@ -71,7 +65,7 @@ export default function ContactBentoSection() {
       <BentoGrid>
         {/* Main contact card */}
         <motion.div
-          className="lg:col-span-8 md:col-span-4"
+          className="lg:col-span-9 md:col-span-4"
           initial={{ opacity: 0, y: 16 }}
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5 }}
@@ -125,36 +119,18 @@ export default function ContactBentoSection() {
               </div>
             </div>
 
-            {/* Proof links */}
-            <div className="border-t border-white/[0.08] pt-4">
-              <p className="mb-3 font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500">
-                Proof
-              </p>
-              <div className="flex flex-wrap gap-4">
-                {proofLinks.map((link) => (
-                  <SmartLink
-                    key={link.label}
-                    href={link.href}
-                    className="inline-flex items-center justify-between gap-2 rounded-lg border border-white/[0.08] bg-white/[0.02] px-3 py-2 text-xs text-indigo-300 transition-all hover:border-indigo-300/40 hover:text-indigo-200"
-                  >
-                    {link.label}
-                    <ArrowUpRight size={12} />
-                  </SmartLink>
-                ))}
-              </div>
-            </div>
           </BentoCard>
         </motion.div>
 
         {/* Recruiter packet card */}
         <motion.div
-          className="lg:col-span-4 md:col-span-2"
+          className="lg:col-span-3 md:col-span-2"
           initial={{ opacity: 0, y: 16 }}
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5, delay: 0.08 }}
           viewport={{ once: true }}
         >
-          <BentoCard variant="metric" padding="md" className="flex flex-col gap-4 lg:gap-4">
+          <BentoCard variant="metric" padding="md" className="h-full flex flex-col gap-4 lg:gap-4">
             <div>
               <p className="font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500 mb-4">
                 Application Packet

--- a/src/sections/ContactBentoSection.tsx
+++ b/src/sections/ContactBentoSection.tsx
@@ -34,12 +34,6 @@ const targetRoles = [
   'Technical Lead, Unity',
 ];
 
-const resumeVariants = [
-  { label: 'General Resume', file: 'JamesDeRaja_Resume.pdf' },
-  { label: 'Unity Rendering Focus', file: 'JamesDeRaja_Resume_Unity-Rendering-Performance.pdf' },
-  { label: 'XR Performance Focus', file: 'JamesDeRaja_Resume_XR-Performance-Engineer.pdf' },
-];
-
 export default function ContactBentoSection() {
   return (
     <section id="contact" className="relative mx-auto max-w-screen-2xl px-4 py-20 pb-24 sm:px-6 lg:px-8">
@@ -128,7 +122,7 @@ export default function ContactBentoSection() {
           </BentoCard>
         </motion.div>
 
-        {/* Resume variants card */}
+        {/* Resume card */}
         <motion.div
           className="lg:col-span-4 md:col-span-2"
           initial={{ opacity: 0, y: 16 }}
@@ -139,32 +133,27 @@ export default function ContactBentoSection() {
           <BentoCard variant="metric" padding="md" className="h-full flex flex-col gap-5">
             <div>
               <p className="font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500 mb-4">
-                Resume Variants
+                Resume
               </p>
               <div className="space-y-2.5">
-                {resumeVariants.map((r) => (
-                  <a
-                    key={r.file}
-                    href={`/resume/${r.file}`}
-                    download
-                    className="group flex items-center justify-between gap-3 rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-3 hover:border-neon/25 hover:bg-neon/[0.04] transition-all duration-200"
-                  >
-                    <div className="flex items-center gap-2.5">
-                      <FileText size={13} className="text-slate-500 group-hover:text-neon transition-colors" />
-                      <span className="text-xs text-slate-300 transition-colors">
-                        {r.label}
-                      </span>
-                    </div>
-                    <Download size={12} className="text-slate-600 group-hover:text-neon transition-colors flex-shrink-0" />
-                  </a>
-                ))}
+                <a
+                  href="/resume/James%20DeRaja%20Resume.pdf"
+                  download
+                  className="group flex items-center justify-between gap-3 rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-3 hover:border-neon/25 hover:bg-neon/[0.04] transition-all duration-200"
+                >
+                  <div className="flex items-center gap-2.5">
+                    <FileText size={13} className="text-slate-500 group-hover:text-neon transition-colors" />
+                    <span className="text-xs text-slate-300 transition-colors">Download Resume</span>
+                  </div>
+                  <Download size={12} className="text-slate-600 group-hover:text-neon transition-colors flex-shrink-0" />
+                </a>
               </div>
             </div>
 
             {/* Online resume */}
             <div className="border-t border-white/[0.05] pt-4">
               <SmartLink
-                href="/resume/viewer.html?file=JamesDeRaja_Resume.pdf"
+                href="/resume/viewer.html?file=James%20DeRaja%20Resume.pdf"
                 className="btn-primary flex items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-sm font-medium w-full"
               >
                 <FileText size={14} />

--- a/src/sections/ContactBentoSection.tsx
+++ b/src/sections/ContactBentoSection.tsx
@@ -34,12 +34,6 @@ const targetRoles = [
   'Technical Lead, Unity',
 ];
 
-const quickFitRows = [
-  '13+ years Unity / real-time systems',
-  'XR, rendering, ECS, multiplayer',
-  'Open to remote worldwide + relocation',
-];
-
 const proofLinks = [
   { label: 'View Case Studies', href: '#case-studies' },
   { label: 'View GitHub', href: 'https://github.com/JamesDeRaja' },
@@ -83,7 +77,7 @@ export default function ContactBentoSection() {
           transition={{ duration: 0.5 }}
           viewport={{ once: true }}
         >
-          <BentoCard variant="featured" padding="lg" className="h-full flex flex-col gap-5">
+          <BentoCard variant="featured" padding="lg" className="flex flex-col gap-5">
             {/* Contact links */}
             <div>
               <p className="font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500 mb-4">
@@ -115,12 +109,20 @@ export default function ContactBentoSection() {
 
             {/* Target roles */}
             <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-4">
-              <p className="font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500">
-                Target Roles
+              <p className="text-sm text-slate-300 leading-relaxed">
+                Targeting senior Unity, rendering, XR performance, and real-time systems roles where
+                profiler evidence, frame-budget discipline, and scalable architecture matter.
               </p>
-              <p className="mt-2 text-sm text-slate-300 leading-relaxed">
-                {targetRoles.join(' · ')}
-              </p>
+              <div className="mt-3 flex flex-wrap gap-1.5">
+                {targetRoles.map((role) => (
+                  <span
+                    key={role}
+                    className="chip-glow rounded-full px-2.5 py-0.5 font-mono text-[11px]"
+                  >
+                    {role}
+                  </span>
+                ))}
+              </div>
             </div>
           </BentoCard>
         </motion.div>
@@ -133,12 +135,12 @@ export default function ContactBentoSection() {
           transition={{ duration: 0.5, delay: 0.08 }}
           viewport={{ once: true }}
         >
-          <BentoCard variant="metric" padding="md" className="h-full flex flex-col gap-4 lg:gap-5 lg:px-6 lg:py-6">
+          <BentoCard variant="metric" padding="md" className="flex flex-col gap-4 lg:gap-4 lg:px-7 lg:py-7">
             <div>
               <p className="font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500 mb-4">
                 Application Packet
               </p>
-              <div className="space-y-3">
+              <div className="space-y-4">
                 <a
                   href="/resume/James%20DeRaja%20Resume.pdf"
                   download
@@ -152,33 +154,9 @@ export default function ContactBentoSection() {
                   className="inline-flex w-full items-center justify-center gap-2 rounded-xl border border-white/[0.08] bg-white/[0.02] px-4 py-3 text-sm font-medium text-indigo-300 transition-all hover:border-indigo-300/40 hover:text-indigo-200"
                 >
                   <FileText size={14} />
-                  View Online
+                  View Resume Online
                 </SmartLink>
               </div>
-            </div>
-
-            {/* Quick fit summary */}
-            <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-3">
-              <p className="font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500">
-                Quick Fit
-              </p>
-              <div className="mt-2 space-y-1.5">
-                {quickFitRows.map((row) => (
-                  <p key={row} className="text-xs text-slate-300 leading-relaxed">
-                    {row}
-                  </p>
-                ))}
-              </div>
-            </div>
-
-            {/* Best fit */}
-            <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-3">
-              <p className="font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500">
-                Best Fit
-              </p>
-              <p className="mt-2 text-xs text-slate-300 leading-relaxed">
-                Rendering · XR Performance · Unity Systems · Technical Lead
-              </p>
             </div>
 
             {/* Proof links */}
@@ -186,7 +164,7 @@ export default function ContactBentoSection() {
               <p className="font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500 mb-2.5">
                 Proof Links
               </p>
-              <div className="grid grid-cols-1 gap-2 sm:grid-cols-3 md:grid-cols-1">
+              <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-3 md:grid-cols-1">
                 {proofLinks.map((link) => (
                   <SmartLink
                     key={link.label}
@@ -207,7 +185,7 @@ export default function ContactBentoSection() {
                 <p className="text-xs font-semibold text-emerald-400">Available</p>
               </div>
               <p className="text-[11px] text-slate-400">
-                Senior roles · Remote worldwide · Relocation open
+                Senior roles · Remote worldwide · Open to relocation
               </p>
             </div>
           </BentoCard>

--- a/src/sections/ContactBentoSection.tsx
+++ b/src/sections/ContactBentoSection.tsx
@@ -155,7 +155,6 @@ export default function ContactBentoSection() {
 
               {/* Availability status */}
               <div className="mt-5 w-full rounded-xl border border-emerald-500/15 bg-emerald-500/[0.05] px-4 py-2">
-                <p className="mb-1 text-[11px] text-emerald-300/80">Available for senior roles</p>
                 <div className="mb-1 flex items-center gap-2">
                   <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 animate-pulse" />
                   <p className="text-xs font-semibold text-emerald-400">Available</p>

--- a/src/sections/HeroBentoSection.tsx
+++ b/src/sections/HeroBentoSection.tsx
@@ -126,7 +126,7 @@ export default function HeroBentoSection() {
                 <ArrowRight size={14} className="transition group-hover:translate-x-1" />
               </a>
               <SmartLink
-                href="/resume/viewer.html?file=JamesDeRaja_Resume.pdf"
+                href="/resume/viewer.html?file=James%20DeRaja%20Resume.pdf"
                 className="btn-secondary inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-medium"
               >
                 <FileText size={14} />


### PR DESCRIPTION
### Motivation
- Reduce complexity in the resume UI by exposing a single authoritative resume PDF and two clear actions (download + view online). 
- Ensure all resume links consistently point to the exact PDF file that will be used for viewing and downloads.

### Description
- Removed the multiple resume-variant UI and replaced it with a single `Download Resume` action that points to `James DeRaja Resume.pdf` and a `View Online` action that opens the viewer for the same file.
- Updated link targets across the site (`Navbar`, `Hero` CTA, `Footer`, and `Contact` card) to reference the URL-encoded `James DeRaja Resume.pdf`.
- Simplified the resume viewer `public/resume/viewer.html` allowlist/default to only accept `James DeRaja Resume.pdf` and use `encodeURIComponent` when building the iframe `src`.
- Removed the `resumeVariants` usage from `src/sections/ContactBentoSection.tsx` and adjusted the contact card content to show the two actions.

### Testing
- Ran `npm run build` and the production build completed successfully (Vite build output: `built in 5.16s`).
- Ran `npm run lint` and it failed due to a pre-existing unrelated lint error in `src/caseStudies/pages/SoftMaskProCaseStudyPage.tsx` (`cardVariants` assigned but never used).
- Attempted to capture a UI screenshot with Playwright in the environment but the workflow could not fully complete due to host/browser dependency and download restrictions (Playwright browser install/download issues).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f03784616883248b1a9e6dfd39c043)