### PR TITLE
Update resume filename to "James De Raja Resume.pdf"

### DIFF
--- a/public/resume/viewer.html
+++ b/public/resume/viewer.html
@@ -25,11 +25,11 @@
   <body>
     <iframe id="resumeFrame" title="Resume PDF"></iframe>
     <script>
-      const allowedFiles = new Set(['James DeRaja Resume.pdf']);
+      const allowedFiles = new Set(['James De Raja Resume.pdf']);
 
       const params = new URLSearchParams(window.location.search);
-      const file = params.get('file') || 'James DeRaja Resume.pdf';
-      const selectedFile = allowedFiles.has(file) ? file : 'James DeRaja Resume.pdf';
+      const file = params.get('file') || 'James De Raja Resume.pdf';
+      const selectedFile = allowedFiles.has(file) ? file : 'James De Raja Resume.pdf';
 
       const resumeName = selectedFile.replace(/\.pdf$/i, '');
       document.title = resumeName;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,7 +9,7 @@ export default function Footer() {
           <SmartLink href="mailto:jamesderaja@gmail.com" className="transition hover:text-neon">Email</SmartLink>
           <SmartLink href="https://www.linkedin.com/in/james-de-raja/" className="transition hover:text-neon">LinkedIn</SmartLink>
           <SmartLink href="https://github.com/JamesDeRaja" className="transition hover:text-neon">GitHub</SmartLink>
-          <SmartLink href="/resume/viewer.html?file=James%20DeRaja%20Resume.pdf" className="transition hover:text-neon">Resume</SmartLink>
+          <SmartLink href="/resume/viewer.html?file=James%20De%20Raja%20Resume.pdf" className="transition hover:text-neon">Resume</SmartLink>
         </div>
       </div>
     </footer>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -78,13 +78,13 @@ export default function Navbar() {
         {/* Actions */}
         <div className="flex items-center gap-2">
           <SmartLink
-            href="/resume/viewer.html?file=James%20DeRaja%20Resume.pdf"
+            href="/resume/viewer.html?file=James%20De%20Raja%20Resume.pdf"
             className="btn-primary hidden rounded-lg px-4 py-2 text-sm font-medium sm:inline-flex"
           >
             View Resume
           </SmartLink>
           <a
-            href="/resume/James%20DeRaja%20Resume.pdf"
+            href="/resume/James%20De%20Raja%20Resume.pdf"
             download
             className="rounded-lg border border-white/10 p-2 text-slate-400 transition hover:border-neon/30 hover:text-neon"
             aria-label="Download resume PDF"

--- a/src/sections/ContactBentoSection.tsx
+++ b/src/sections/ContactBentoSection.tsx
@@ -137,7 +137,7 @@ export default function ContactBentoSection() {
               </p>
               <div className="mt-6 space-y-4">
                 <a
-                  href="/resume/James%20DeRaja%20Resume.pdf"
+                  href="/resume/James%20De%20Raja%20Resume.pdf"
                   download
                   className="btn-primary group flex h-12 w-full items-center justify-center gap-2 rounded-xl px-4 text-sm font-semibold"
                 >
@@ -145,7 +145,7 @@ export default function ContactBentoSection() {
                   Download Resume
                 </a>
                 <SmartLink
-                  href="/resume/viewer.html?file=James%20DeRaja%20Resume.pdf"
+                  href="/resume/viewer.html?file=James%20De%20Raja%20Resume.pdf"
                   className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-xl border border-white/[0.12] bg-white/[0.02] px-4 text-sm font-medium text-indigo-300 transition-all hover:border-indigo-300/40 hover:text-indigo-200"
                 >
                   <FileText size={14} />

--- a/src/sections/HeroBentoSection.tsx
+++ b/src/sections/HeroBentoSection.tsx
@@ -126,7 +126,7 @@ export default function HeroBentoSection() {
                 <ArrowRight size={14} className="transition group-hover:translate-x-1" />
               </a>
               <SmartLink
-                href="/resume/viewer.html?file=James%20DeRaja%20Resume.pdf"
+                href="/resume/viewer.html?file=James%20De%20Raja%20Resume.pdf"
                 className="btn-secondary inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-medium"
               >
                 <FileText size={14} />


### PR DESCRIPTION
### Motivation
- Standardize the public resume filename to include the space in the name (`James De Raja Resume.pdf`) so viewer allowlist and site links point to the actual file present in `public/resume`.

### Description
- Changed the resume viewer allowlist, default, and fallback filename from `James DeRaja Resume.pdf` to `James De Raja Resume.pdf` in `public/resume/viewer.html`.
- Updated URL-encoded resume links to `James%20De%20Raja%20Resume.pdf` in `src/components/Footer.tsx`, `src/components/Navbar.tsx`, `src/sections/HeroBentoSection.tsx`, and `src/sections/ContactBentoSection.tsx`.
- Committed the updates with the message `Update resume filename references to 'James De Raja'`.

### Testing
- Verified no remaining references to the old filename using `rg -n "James DeRaja Resume\.pdf|James%20DeRaja%20Resume\.pdf"` which returned no matches in the updated files (success).
- Performed `git commit` which reported the changes were recorded (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c2b456d88324bfa704161b683155)