### PR TITLE
Add Visual Journey interactive resume and update site domain to james.alphaden.club

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
       name="description"
       content="Real-time performance engineer with 13+ years in Unity. Shipped mobile titles, XR/VR optimization, GPU/CPU bottleneck isolation, and frame pacing research with profiler-validated measurements."
     />
-    <link rel="canonical" href="https://jamesderaja.com/" />
+    <link rel="canonical" href="https://james.alphaden.club/" />
     <meta name="robots" content="index,follow" />
     <meta name="author" content="James De Raja" />
     <meta
@@ -23,7 +23,7 @@
       content="13+ years and 100+ shipped titles. GPU/CPU bottleneck isolation, XR stereo rendering, and frame pacing research with profiler evidence."
     />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://jamesderaja.com/" />
+    <meta property="og:url" content="https://james.alphaden.club/" />
     <meta property="og:image" content="/og-image.png" />
     <meta property="og:site_name" content="James De Raja Portfolio" />
     <meta name="twitter:card" content="summary_large_image" />

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Allow: /
-Sitemap: https://jamesderaja.com/sitemap.xml
+Sitemap: https://james.alphaden.club/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,87 +1,93 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://jamesderaja.com/</loc>
+    <loc>https://james.alphaden.club/</loc>
     <lastmod>2026-03-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://jamesderaja.com/case-studies/xr-stress-lab</loc>
+    <loc>https://james.alphaden.club/case-studies/xr-stress-lab</loc>
     <lastmod>2025-01-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jamesderaja.com/case-studies/softmaskpro</loc>
+    <loc>https://james.alphaden.club/case-studies/softmaskpro</loc>
     <lastmod>2025-01-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jamesderaja.com/case-studies/profiling-toolkit</loc>
+    <loc>https://james.alphaden.club/case-studies/profiling-toolkit</loc>
     <lastmod>2025-01-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jamesderaja.com/case-studies/sneaky-warrior-3d</loc>
+    <loc>https://james.alphaden.club/case-studies/sneaky-warrior-3d</loc>
     <lastmod>2025-01-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://jamesderaja.com/case-studies/published-mobile-projects</loc>
+    <loc>https://james.alphaden.club/case-studies/published-mobile-projects</loc>
     <lastmod>2025-01-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://jamesderaja.com/lab/overdraw</loc>
+    <loc>https://james.alphaden.club/lab/overdraw</loc>
     <lastmod>2025-01-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://jamesderaja.com/lab/msaa</loc>
+    <loc>https://james.alphaden.club/lab/msaa</loc>
     <lastmod>2025-01-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://jamesderaja.com/lab/msaa-overdraw</loc>
+    <loc>https://james.alphaden.club/lab/msaa-overdraw</loc>
     <lastmod>2025-01-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://jamesderaja.com/lab/instancing</loc>
+    <loc>https://james.alphaden.club/lab/instancing</loc>
     <lastmod>2025-01-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://jamesderaja.com/lab/frame-pacing</loc>
+    <loc>https://james.alphaden.club/lab/frame-pacing</loc>
     <lastmod>2025-01-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://jamesderaja.com/lab/frame-pacing-vs-fps</loc>
+    <loc>https://james.alphaden.club/lab/frame-pacing-vs-fps</loc>
     <lastmod>2025-01-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://jamesderaja.com/lab/xr-frame-timing</loc>
+    <loc>https://james.alphaden.club/lab/xr-frame-timing</loc>
     <lastmod>2025-01-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://jamesderaja.com/lab/overdraw-stereo</loc>
+    <loc>https://james.alphaden.club/lab/overdraw-stereo</loc>
     <lastmod>2025-01-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://james.alphaden.club/visual-journey</loc>
+    <lastmod>2026-04-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
   </url>
 </urlset>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import XRFrameTimingLabPage from './lab/pages/XRFrameTimingLabPage';
 import SiteLayout from './layouts/SiteLayout';
 import HomePage from './pages/HomePage';
 import NotFoundPage from './pages/NotFoundPage';
+import VisualJourney from './pages/VisualJourney';
 
 function App() {
   return (
@@ -43,6 +44,7 @@ function App() {
         <Route path="/lab/frame-pacing-vs-fps" element={<FramePacingVsFPSLabPage />} />
         <Route path="/lab/xr-frame-timing" element={<XRFrameTimingLabPage />} />
         <Route path="/lab/overdraw-stereo" element={<OverdrawStereoLabPage />} />
+        <Route path="/visual-journey" element={<VisualJourney />} />
         <Route path="*" element={<NotFoundPage />} />
       </Route>
     </Routes>

--- a/src/caseStudies/pages/ProfilingToolkitCaseStudyPage.tsx
+++ b/src/caseStudies/pages/ProfilingToolkitCaseStudyPage.tsx
@@ -16,7 +16,7 @@ export default function ProfilingToolkitCaseStudyPage() {
         <Seo
           title="Profiling Toolkit Case Study — James De Raja"
           description="Case study on a Unity runtime profiling overlay that shortens bottleneck triage from symptom capture to mitigation-ready evidence."
-          url="https://jamesderaja.com/case-studies/profiling-toolkit"
+          url="https://james.alphaden.club/case-studies/profiling-toolkit"
           keywords="Unity profiler toolkit, runtime overlay, bottleneck triage, performance telemetry"
           type="article"
           structuredData={{

--- a/src/caseStudies/pages/PublishedMobileProjectsCaseStudyPage.tsx
+++ b/src/caseStudies/pages/PublishedMobileProjectsCaseStudyPage.tsx
@@ -24,7 +24,7 @@ export default function PublishedMobileProjectsCaseStudyPage() {
       <Seo
         title="Sneaky Warrior 3D Case Study — James De Raja"
         description="Mobile performance case study covering frame budget stabilization for Sneaky Warrior 3D under heavy AI, ragdoll, and projectile load."
-        url="https://jamesderaja.com/case-studies/published-mobile-projects"
+        url="https://james.alphaden.club/case-studies/published-mobile-projects"
         keywords="mobile performance, Unity optimization, frame budget, Sneaky Warrior 3D, frame pacing"
         type="article"
         structuredData={{

--- a/src/caseStudies/pages/SoftMaskProCaseStudyPage.tsx
+++ b/src/caseStudies/pages/SoftMaskProCaseStudyPage.tsx
@@ -78,7 +78,7 @@ export default function SoftMaskProCaseStudyPage() {
         <Seo
           title="SoftMaskPro Optimization Case Study — James De Raja"
           description="SoftMaskPro profiling and patching case study focused on UI mask draw calls, render pass overhead, and frame-time stabilization in Unity."
-          url="https://jamesderaja.com/case-studies/softmaskpro"
+          url="https://james.alphaden.club/case-studies/softmaskpro"
           keywords="SoftMaskPro, Unity UI optimization, draw calls, frame timing, profiling"
           type="article"
           structuredData={{

--- a/src/caseStudies/pages/UpdateStrategiesCaseStudyPage.tsx
+++ b/src/caseStudies/pages/UpdateStrategiesCaseStudyPage.tsx
@@ -157,7 +157,7 @@ export default function UpdateStrategiesCaseStudyPage() {
       <Seo
         title="Update Strategies at Scale — James De Raja"
         description="Profiler-driven comparison of 4 Unity update architectures (MonoBehaviour, Manager, ECS) across 10,000 entities. Frame time reduced from ~40 ms to ~9.4 ms."
-        url="https://jamesderaja.com/case-studies/update-strategies-scale"
+        url="https://james.alphaden.club/case-studies/update-strategies-scale"
         keywords="Unity ECS, MonoBehaviour update, central manager, DOTS, performance, 10000 entities, Unity profiling"
         type="article"
         structuredData={{

--- a/src/caseStudies/pages/UpdateStrategiesVariantAPage.tsx
+++ b/src/caseStudies/pages/UpdateStrategiesVariantAPage.tsx
@@ -76,7 +76,7 @@ export default function UpdateStrategiesVariantAPage() {
       <Seo
         title="Variant A — Lifecycle Control | Update Strategies at Scale"
         description="Deep dive into Scene A of the Unity update architecture study: 10,000 passive enemies with bullet lifecycle churn. Establishes the render and GC baseline."
-        url="https://jamesderaja.com/case-studies/update-strategies-scale/variant-a"
+        url="https://james.alphaden.club/case-studies/update-strategies-scale/variant-a"
         keywords="Unity lifecycle, MonoBehaviour baseline, Instantiate Destroy, GC alloc, Unity profiling, 10000 entities"
         type="article"
       />

--- a/src/caseStudies/pages/UpdateStrategiesVariantBPage.tsx
+++ b/src/caseStudies/pages/UpdateStrategiesVariantBPage.tsx
@@ -74,7 +74,7 @@ export default function UpdateStrategiesVariantBPage() {
       <Seo
         title="Variant B — Per-Object Update | Update Strategies at Scale"
         description="Deep dive into Scene B: 10,000 MonoBehaviour Update calls, 8.62 ms ScriptRunBehaviourUpdate, and why per-object update does not scale in Unity."
-        url="https://jamesderaja.com/case-studies/update-strategies-scale/variant-b"
+        url="https://james.alphaden.club/case-studies/update-strategies-scale/variant-b"
         keywords="MonoBehaviour Update, ScriptRunBehaviourUpdate, Unity performance, 10000 entities, update dispatch overhead"
         type="article"
       />

--- a/src/caseStudies/pages/UpdateStrategiesVariantCPage.tsx
+++ b/src/caseStudies/pages/UpdateStrategiesVariantCPage.tsx
@@ -83,7 +83,7 @@ export default function UpdateStrategiesVariantCPage() {
       <Seo
         title="Variant C — Central Manager | Update Strategies at Scale"
         description="Deep dive into Scene C: a single manager MonoBehaviour replaces 10,000 per-object Updates. Script cost drops from 8.62 ms to 4.34 ms, but Transform iteration remains the bottleneck."
-        url="https://jamesderaja.com/case-studies/update-strategies-scale/variant-c"
+        url="https://james.alphaden.club/case-studies/update-strategies-scale/variant-c"
         keywords="Unity central manager, MonoBehaviour optimization, Transform iteration, Unity performance, update pattern"
         type="article"
       />

--- a/src/caseStudies/pages/UpdateStrategiesVariantDPage.tsx
+++ b/src/caseStudies/pages/UpdateStrategiesVariantDPage.tsx
@@ -107,7 +107,7 @@ export default function UpdateStrategiesVariantDPage() {
       <Seo
         title="Variant D — ECS (DOTS) | Update Strategies at Scale"
         description="Deep dive into Scene D: Unity ECS replaces MonoBehaviours entirely. Frame time drops from ~40 ms to ~9.4 ms — a 4× improvement under 10,000 enemies and maximum bullet pressure."
-        url="https://jamesderaja.com/case-studies/update-strategies-scale/variant-d"
+        url="https://james.alphaden.club/case-studies/update-strategies-scale/variant-d"
         keywords="Unity ECS, DOTS, entity component system, Burst compiler, chunk iteration, MonoBehaviour replacement, Unity performance"
         type="article"
       />

--- a/src/caseStudies/pages/XRStressLabCaseStudyPage.tsx
+++ b/src/caseStudies/pages/XRStressLabCaseStudyPage.tsx
@@ -62,7 +62,7 @@ export default function XRStressLabCaseStudyPage() {
       <Seo
         title="XR Stress Lab Case Study — James De Raja"
         description="Controlled XR stress tests isolating overdraw, MSAA bandwidth, submission overhead, and frame pacing variance with profiler-backed evidence."
-        url="https://jamesderaja.com/case-studies/xr-stress-lab"
+        url="https://james.alphaden.club/case-studies/xr-stress-lab"
         keywords="XR stress lab, overdraw, MSAA, instancing, frame pacing, Unity profiling"
         type="article"
         structuredData={{

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -10,6 +10,7 @@ export default function Footer() {
           <SmartLink href="https://www.linkedin.com/in/james-de-raja/" className="transition hover:text-neon">LinkedIn</SmartLink>
           <SmartLink href="https://github.com/JamesDeRaja" className="transition hover:text-neon">GitHub</SmartLink>
           <SmartLink href="/resume/viewer.html?file=James%20DeRaja%20Resume.pdf" className="transition hover:text-neon">Resume</SmartLink>
+          <SmartLink href="/visual-journey" className="transition hover:text-neon">Visual Journey</SmartLink>
         </div>
       </div>
     </footer>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -78,6 +78,12 @@ export default function Navbar() {
         {/* Actions */}
         <div className="flex items-center gap-2">
           <SmartLink
+            href="/visual-journey"
+            className="hidden rounded-lg border border-neon/20 bg-neon/10 px-3 py-2 text-sm font-medium text-neon transition hover:border-neon/40 hover:bg-neon/15 lg:inline-flex"
+          >
+            Visual Resume
+          </SmartLink>
+          <SmartLink
             href="/resume/viewer.html?file=James%20DeRaja%20Resume.pdf"
             className="btn-primary hidden rounded-lg px-4 py-2 text-sm font-medium sm:inline-flex"
           >
@@ -121,6 +127,13 @@ export default function Navbar() {
             className="overflow-hidden border-t border-white/5 bg-void-950/95 backdrop-blur-xl md:hidden"
           >
             <div className="px-4 py-4 space-y-1">
+              <SmartLink
+                href="/visual-journey"
+                className="mb-2 block w-full rounded-lg border border-neon/20 bg-neon/10 px-3 py-3 text-left text-sm font-medium text-neon transition hover:border-neon/40 hover:bg-neon/15"
+                onClick={() => setMobileOpen(false)}
+              >
+                Visual Resume
+              </SmartLink>
               {navItems.map((item) => (
                 <button
                   key={item.label}

--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -26,7 +26,7 @@ export function Seo({
     '@type': 'Person',
     name: 'James De Raja',
     jobTitle: 'Senior Real-Time Performance Engineer',
-    url: 'https://jamesderaja.com',
+    url: 'https://james.alphaden.club',
     email: 'jamesderaja@gmail.com',
     address: {
       '@type': 'PostalAddress',

--- a/src/components/SmartLink.tsx
+++ b/src/components/SmartLink.tsx
@@ -6,7 +6,7 @@ type SmartLinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
   children: ReactNode;
 };
 
-const INTERNAL_HOSTNAMES = new Set(['jamesderaja.com', 'www.jamesderaja.com']);
+const INTERNAL_HOSTNAMES = new Set(['james.alphaden.club', 'www.james.alphaden.club']);
 
 function isHttpUrl(href: string) {
   return href.startsWith('http://') || href.startsWith('https://');

--- a/src/components/visual-journey/FloatingMetric.tsx
+++ b/src/components/visual-journey/FloatingMetric.tsx
@@ -1,0 +1,29 @@
+import { motion, useReducedMotion } from 'framer-motion';
+
+type FloatingMetricProps = {
+  text: string;
+  index?: number;
+};
+
+export default function FloatingMetric({ text, index = 0 }: FloatingMetricProps) {
+  const reduceMotion = useReducedMotion();
+
+  return (
+    <motion.div
+      className="rounded-xl border border-neon/20 bg-neon/5 px-3 py-2 text-xs font-semibold text-slate-100"
+      initial={{ opacity: 0, scale: 0.96 }}
+      whileInView={{ opacity: 1, scale: 1 }}
+      viewport={{ once: true, amount: 0.2 }}
+      transition={{ duration: 0.3, delay: index * 0.07 }}
+      animate={
+        reduceMotion
+          ? undefined
+          : {
+              y: [0, -4, 0],
+            }
+      }
+    >
+      {text}
+    </motion.div>
+  );
+}

--- a/src/components/visual-journey/JourneyStage.tsx
+++ b/src/components/visual-journey/JourneyStage.tsx
@@ -1,0 +1,80 @@
+import { motion, useReducedMotion } from 'framer-motion';
+import FloatingMetric from './FloatingMetric';
+import ThoughtBubble from './ThoughtBubble';
+import VisualJourneyCharacter from './VisualJourneyCharacter';
+import type { JourneyStageData } from './types';
+
+type JourneyStageProps = {
+  stage: JourneyStageData;
+  index: number;
+  isActive: boolean;
+  isMobile: boolean;
+  onEnter: (index: number) => void;
+  progress: number;
+};
+
+export default function JourneyStage({
+  stage,
+  index,
+  isActive,
+  isMobile,
+  onEnter,
+  progress,
+}: JourneyStageProps) {
+  const reduceMotion = useReducedMotion();
+
+  return (
+    <motion.section
+      id={stage.id}
+      className="scroll-mt-24 rounded-3xl border border-white/10 bg-void-900/60 p-6 backdrop-blur-xl md:p-8"
+      initial={{ opacity: 0, y: reduceMotion ? 0 : 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ amount: 0.45 }}
+      transition={{ duration: 0.45, ease: 'easeOut' }}
+      onViewportEnter={() => onEnter(index)}
+    >
+      <div className="mb-5 flex flex-wrap items-center gap-3">
+        <span className="rounded-full border border-neon/20 bg-neon/10 px-3 py-1 text-xs font-mono uppercase tracking-wide text-neon">
+          Phase {index + 1}
+        </span>
+        <h3 className="text-xl font-semibold text-white">{stage.title}</h3>
+      </div>
+      <p className="mb-5 text-sm leading-relaxed text-slate-300">{stage.description}</p>
+
+      {isMobile && (
+        <div className="mb-6 md:hidden">
+          <VisualJourneyCharacter stage={stage} progress={progress} mobile />
+        </div>
+      )}
+
+      {!!stage.chips?.length && (
+        <div className="mb-4 flex flex-wrap gap-2">
+          {stage.chips.map((chip) => (
+            <span
+              key={chip}
+              className="rounded-full border border-white/15 bg-white/5 px-3 py-1 text-xs font-semibold text-slate-200"
+            >
+              {chip}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="mb-4 flex flex-wrap gap-2">
+        {stage.bubbles.map((bubble, bubbleIndex) => (
+          <ThoughtBubble key={bubble} text={bubble} index={bubbleIndex} />
+        ))}
+      </div>
+
+      {!!stage.metrics?.length && (
+        <div className="grid gap-2 sm:grid-cols-2">
+          {stage.metrics.map((metric, metricIndex) => (
+            <FloatingMetric key={metric} text={metric} index={metricIndex} />
+          ))}
+        </div>
+      )}
+
+      {isActive && <div className="mt-6 h-px bg-gradient-to-r from-neon/80 via-electric/70 to-transparent" />}
+    </motion.section>
+  );
+}

--- a/src/components/visual-journey/ScrollProgressRail.tsx
+++ b/src/components/visual-journey/ScrollProgressRail.tsx
@@ -1,0 +1,34 @@
+import { motion } from 'framer-motion';
+import type { JourneyStageData } from './types';
+
+type ScrollProgressRailProps = {
+  stages: JourneyStageData[];
+  activeIndex: number;
+};
+
+export default function ScrollProgressRail({ stages, activeIndex }: ScrollProgressRailProps) {
+  return (
+    <aside className="sticky top-24 hidden w-56 self-start rounded-2xl border border-white/10 bg-void-900/70 p-4 backdrop-blur-xl xl:block">
+      <p className="mb-4 text-xs font-mono uppercase tracking-[0.18em] text-slate-400">Journey Progress</p>
+      <div className="relative pl-4">
+        <div className="absolute left-1.5 top-1 h-[calc(100%-8px)] w-px bg-white/10" />
+        {stages.map((stage, index) => (
+          <button
+            key={stage.id}
+            type="button"
+            onClick={() => document.getElementById(stage.id)?.scrollIntoView({ behavior: 'smooth', block: 'start' })}
+            className="relative mb-3 block w-full text-left"
+          >
+            <motion.span
+              className={`absolute -left-[0.6rem] top-1.5 h-2.5 w-2.5 rounded-full ${
+                index <= activeIndex ? 'bg-neon' : 'bg-white/20'
+              }`}
+              animate={{ scale: index === activeIndex ? 1.2 : 1 }}
+            />
+            <span className={`text-xs ${index === activeIndex ? 'text-neon' : 'text-slate-400'}`}>{stage.phase}</span>
+          </button>
+        ))}
+      </div>
+    </aside>
+  );
+}

--- a/src/components/visual-journey/ThoughtBubble.tsx
+++ b/src/components/visual-journey/ThoughtBubble.tsx
@@ -1,0 +1,29 @@
+import { motion, useReducedMotion } from 'framer-motion';
+
+type ThoughtBubbleProps = {
+  text: string;
+  index?: number;
+};
+
+export default function ThoughtBubble({ text, index = 0 }: ThoughtBubbleProps) {
+  const reduceMotion = useReducedMotion();
+
+  return (
+    <motion.span
+      className="inline-flex items-center rounded-full border border-neon/20 bg-void-900/70 px-3 py-1 text-xs font-mono text-neon"
+      initial={{ opacity: 0, y: reduceMotion ? 0 : 8 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.4 }}
+      transition={{ duration: 0.35, delay: index * 0.06 }}
+      animate={
+        reduceMotion
+          ? undefined
+          : {
+              y: [0, -6, 0],
+            }
+      }
+    >
+      {text}
+    </motion.span>
+  );
+}

--- a/src/components/visual-journey/VisualJourneyCharacter.tsx
+++ b/src/components/visual-journey/VisualJourneyCharacter.tsx
@@ -1,0 +1,119 @@
+import { motion, useReducedMotion } from 'framer-motion';
+import type { JourneyStageData } from './types';
+
+type VisualJourneyCharacterProps = {
+  stage: JourneyStageData;
+  progress: number;
+  mobile?: boolean;
+};
+
+const stageTints: Record<JourneyStageData['visualState'], string> = {
+  college: 'from-neon/20 via-electric/20 to-transparent',
+  'first-games': 'from-electric/20 via-neon/15 to-transparent',
+  'hyper-casual': 'from-neon/30 via-neon/5 to-transparent',
+  publisher: 'from-electric/30 via-neon/15 to-transparent',
+  performance: 'from-neon/30 via-cyan-500/20 to-transparent',
+  xr: 'from-fuchsia-500/25 via-neon/15 to-transparent',
+  current: 'from-neon/35 via-electric/15 to-transparent',
+};
+
+function StageOverlay({ visualState }: { visualState: JourneyStageData['visualState'] }) {
+  if (visualState === 'xr') {
+    return (
+      <>
+        <div className="absolute inset-x-10 top-16 h-8 rounded-lg border border-fuchsia-400/30 bg-fuchsia-400/10" />
+        <div className="absolute inset-x-14 top-20 h-8 rounded-lg border border-neon/30 bg-neon/10" />
+        <div className="absolute right-12 top-10 h-3 w-3 rounded-full bg-red-400 animate-pulse" />
+      </>
+    );
+  }
+
+  if (visualState === 'performance' || visualState === 'current') {
+    return (
+      <>
+        <div className="absolute left-8 top-12 h-16 w-20 rounded-xl border border-neon/20 bg-void-900/80 p-2">
+          <div className="mb-1 h-1.5 w-1/2 rounded bg-neon/60" />
+          <div className="h-1.5 w-4/5 rounded bg-emerald-300/70" />
+          <div className="mt-2 h-6 rounded bg-gradient-to-r from-neon/50 to-electric/60" />
+        </div>
+        <div className="absolute right-8 top-12 h-16 w-20 rounded-xl border border-neon/20 bg-void-900/80 p-2">
+          <div className="mb-2 h-1.5 w-2/3 rounded bg-red-300/80" />
+          <div className="h-7 rounded border border-white/10">
+            <div className="h-full w-3/5 rounded bg-red-400/60" />
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  if (visualState === 'publisher') {
+    return (
+      <div className="absolute left-1/2 top-8 flex -translate-x-1/2 gap-2">
+        {['Voodoo', 'Lion Studios', 'Supersonic'].map((chip) => (
+          <span key={chip} className="rounded-full border border-white/15 bg-void-900/80 px-3 py-1 text-[10px] font-mono text-slate-300">
+            {chip}
+          </span>
+        ))}
+      </div>
+    );
+  }
+
+  if (visualState === 'hyper-casual' || visualState === 'first-games') {
+    return (
+      <>
+        <div className="absolute left-12 top-16 h-10 w-6 rounded-md border border-neon/20 bg-void-900/80" />
+        <div className="absolute left-24 top-24 h-6 w-6 rounded-md bg-neon/20" />
+        <div className="absolute right-16 top-20 h-5 w-5 rounded-full bg-electric/30" />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="absolute left-10 top-14 h-9 w-14 rounded-md border border-neon/20 bg-void-900/80" />
+      <div className="absolute right-14 top-20 h-8 w-10 rounded-md border border-neon/20 bg-void-900/80" />
+    </>
+  );
+}
+
+export default function VisualJourneyCharacter({ stage, progress, mobile = false }: VisualJourneyCharacterProps) {
+  const reduceMotion = useReducedMotion();
+
+  return (
+    <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-void-900/70 p-6 backdrop-blur-xl">
+      <div className={`pointer-events-none absolute inset-0 bg-gradient-to-br ${stageTints[stage.visualState]}`} />
+      <div className="pointer-events-none absolute inset-0 bg-grid-overlay opacity-40" />
+
+      <StageOverlay visualState={stage.visualState} />
+
+      <motion.div
+        className="relative mx-auto mt-14 flex h-48 w-40 flex-col items-center"
+        animate={
+          reduceMotion
+            ? undefined
+            : {
+                y: mobile ? [0, -2, 0] : [0, -4, 0],
+                rotate: [0, 0.5, -0.5, 0],
+              }
+        }
+        transition={{ duration: 3.2, repeat: Number.POSITIVE_INFINITY, ease: 'easeInOut' }}
+      >
+        <div className="h-14 w-14 rounded-full border border-white/15 bg-gradient-to-br from-slate-300/80 to-slate-500/80" />
+        <div className="mt-2 h-20 w-24 rounded-2xl border border-white/15 bg-gradient-to-br from-neon/30 to-electric/30" />
+        <div className="mt-2 flex w-full justify-between px-2">
+          <div className="h-10 w-7 rounded-full border border-white/15 bg-slate-400/60" />
+          <div className="h-10 w-7 rounded-full border border-white/15 bg-slate-400/60" />
+        </div>
+      </motion.div>
+
+      <motion.div
+        className="relative mt-3 h-2 rounded-full bg-white/10"
+        initial={{ width: 0 }}
+        animate={{ width: '100%' }}
+      >
+        <motion.div className="h-full rounded-full bg-gradient-to-r from-neon to-electric" style={{ width: `${Math.max(8, progress * 100)}%` }} />
+      </motion.div>
+      <p className="mt-3 text-center text-xs font-mono uppercase tracking-[0.2em] text-slate-400">{stage.phase}</p>
+    </div>
+  );
+}

--- a/src/components/visual-journey/VisualJourneyHero.tsx
+++ b/src/components/visual-journey/VisualJourneyHero.tsx
@@ -1,0 +1,44 @@
+import { motion } from 'framer-motion';
+import SmartLink from '../SmartLink';
+
+export default function VisualJourneyHero() {
+  return (
+    <section className="relative overflow-hidden border-b border-white/5 pb-10 pt-12 md:pb-14 md:pt-16">
+      <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-neon/10 via-transparent to-transparent" />
+      <div className="mx-auto max-w-screen-2xl px-4 sm:px-6 lg:px-8">
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.45 }}
+          className="max-w-4xl"
+        >
+          <p className="mb-4 inline-flex rounded-full border border-neon/20 bg-neon/10 px-3 py-1 text-xs font-mono uppercase tracking-[0.18em] text-neon">
+            Visual Journey
+          </p>
+          <h1 className="text-3xl font-semibold leading-tight text-white sm:text-4xl lg:text-5xl">
+            An Interactive Resume Through Real-Time Systems
+          </h1>
+          <p className="mt-5 max-w-3xl text-sm leading-relaxed text-slate-300 sm:text-base">
+            From game prototypes to profiler-backed XR performance engineering — a visual journey through 13+ years of
+            Unity, rendering, and frame-time optimization.
+          </p>
+
+          <div className="mt-7 flex flex-wrap gap-3">
+            <SmartLink
+              href="#journey-start"
+              className="rounded-lg border border-neon/40 bg-neon/15 px-4 py-2 text-sm font-semibold text-neon transition hover:bg-neon/20"
+            >
+              Start the journey
+            </SmartLink>
+            <SmartLink
+              href="/resume/viewer.html?file=James%20DeRaja%20Resume.pdf"
+              className="rounded-lg border border-white/15 bg-white/5 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-neon/30 hover:text-neon"
+            >
+              View standard resume
+            </SmartLink>
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/visual-journey/VisualJourneyPage.tsx
+++ b/src/components/visual-journey/VisualJourneyPage.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useState } from 'react';
+import { motion, useScroll, useTransform } from 'framer-motion';
+import SmartLink from '../SmartLink';
+import JourneyStage from './JourneyStage';
+import ScrollProgressRail from './ScrollProgressRail';
+import VisualJourneyCharacter from './VisualJourneyCharacter';
+import type { JourneyStageData } from './types';
+
+const journeyStages: JourneyStageData[] = [
+  {
+    id: 'journey-stage-college',
+    phase: 'College & foundations',
+    title: 'Learning how systems move',
+    description: 'Built the foundation in programming, logic, and real-time interaction.',
+    bubbles: ['C#', 'Unity', 'Game loops', 'Math', 'Problem solving'],
+    visualState: 'college',
+  },
+  {
+    id: 'journey-stage-first-games',
+    phase: 'Early game development',
+    title: 'From idea to playable loops',
+    description: 'Shipped early prototypes and learned rapid iteration, controls, and game feel.',
+    bubbles: ['Prototype', 'Iteration', 'Game feel', 'Retention'],
+    visualState: 'first-games',
+  },
+  {
+    id: 'journey-stage-mobile-production',
+    phase: 'Hyper-casual production',
+    title: 'Mobile production with measurable outcomes',
+    description: 'Scaled prototype throughput while improving retention and reducing acquisition cost.',
+    bubbles: ['Publisher prototypes', 'Fast iteration loops', 'Mobile systems'],
+    metrics: ['D1 retention improved 27% → 37%', 'CPI reduced to $0.37'],
+    visualState: 'hyper-casual',
+  },
+  {
+    id: 'journey-stage-publisher',
+    phase: 'Publisher collaboration',
+    title: 'Market-tested gameplay delivery',
+    description: 'Collaborated with major publishers and turned validated concepts into public releases.',
+    bubbles: ['50+ commissioned prototypes', '100+ public releases', 'Market-tested gameplay'],
+    chips: ['Voodoo', 'Lion Studios', 'Supersonic'],
+    visualState: 'publisher',
+  },
+  {
+    id: 'journey-stage-performance',
+    phase: 'Performance engineering',
+    title: 'Profiler-backed optimization systems',
+    description: 'Focused on deterministic frame budgets, bottleneck isolation, and production-safe optimizations.',
+    bubbles: ['CPU/GPU bottleneck isolation', 'GC-free systems', 'Frame pacing', 'Profiler-backed experiments'],
+    metrics: ['11ms / 16.6ms frame budgets'],
+    visualState: 'performance',
+  },
+  {
+    id: 'journey-stage-xr',
+    phase: 'XR rendering research',
+    title: 'Rendering cost analysis under XR constraints',
+    description:
+      'Ran XR rendering studies to isolate overdraw amplification, stereo pipeline costs, and tile-based GPU behavior.',
+    bubbles: ['Stereo rendering', 'Overdraw amplification', '+7.27ms GPU cost isolated', 'Tile-based GPU awareness'],
+    visualState: 'xr',
+  },
+  {
+    id: 'journey-stage-current',
+    phase: 'Current positioning',
+    title: 'Senior Real-Time Performance Engineer',
+    description:
+      'Now focused on Unity rendering, frame pacing, XR optimization, and evidence-driven performance engineering.',
+    bubbles: ['Unity Rendering', 'Frame Pacing', 'XR Optimization', 'Performance case studies available'],
+    visualState: 'current',
+  },
+];
+
+function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(() =>
+    typeof window !== 'undefined' ? window.matchMedia('(max-width: 767px)').matches : false,
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const query = window.matchMedia('(max-width: 767px)');
+    const update = () => setIsMobile(query.matches);
+    update();
+    query.addEventListener('change', update);
+
+    return () => query.removeEventListener('change', update);
+  }, []);
+
+  return isMobile;
+}
+
+export default function VisualJourneyPage() {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const isMobile = useIsMobile();
+  const { scrollYProgress } = useScroll();
+  const railProgress = useTransform(scrollYProgress, [0, 1], [0.92, 1]);
+  const stageProgress = (activeIndex + 1) / journeyStages.length;
+
+  return (
+    <div className="mx-auto max-w-screen-2xl px-4 pb-16 sm:px-6 lg:px-8" id="journey-start">
+      <div className="mt-8 grid gap-6 xl:grid-cols-[220px_minmax(0,1fr)]">
+        <ScrollProgressRail stages={journeyStages} activeIndex={activeIndex} />
+
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_430px]">
+          <div className="order-2 space-y-6 lg:order-1">
+            {journeyStages.map((stage, index) => (
+              <JourneyStage
+                key={stage.id}
+                stage={stage}
+                index={index}
+                isActive={index === activeIndex}
+                isMobile={isMobile}
+                onEnter={setActiveIndex}
+                progress={stageProgress}
+              />
+            ))}
+
+            <section className="rounded-3xl border border-white/10 bg-void-900/60 p-6 backdrop-blur-xl md:p-8">
+              <h2 className="text-2xl font-semibold text-white">Want the standard version?</h2>
+              <p className="mt-3 text-sm text-slate-300">
+                Open the resume, case studies, or GitHub evidence behind the visual journey.
+              </p>
+
+              <div className="mt-6 grid gap-2 rounded-2xl border border-white/10 bg-void-950/70 p-4 text-sm text-slate-300 sm:grid-cols-2">
+                <p>• 13+ years real-time systems experience</p>
+                <p>• 10+ years Unity</p>
+                <p>• Mobile games, rendering, XR, frame pacing</p>
+                <p>• Published with Voodoo, Lion Studios, Supersonic</p>
+                <p>• Performance case studies available</p>
+              </div>
+
+              <div className="mt-6 flex flex-wrap gap-3">
+                <SmartLink href="/resume/viewer.html?file=James%20DeRaja%20Resume.pdf" className="rounded-lg border border-neon/40 bg-neon/15 px-4 py-2 text-sm font-semibold text-neon">
+                  View Resume
+                </SmartLink>
+                <a href="/resume/James%20DeRaja%20Resume.pdf" download className="rounded-lg border border-white/15 bg-white/5 px-4 py-2 text-sm font-semibold text-slate-200">
+                  Download Resume
+                </a>
+                <SmartLink href="/case-studies/xr-stress-lab" className="rounded-lg border border-white/15 bg-white/5 px-4 py-2 text-sm font-semibold text-slate-200">
+                  View Case Studies
+                </SmartLink>
+                <SmartLink href="https://github.com/JamesDeRaja" className="rounded-lg border border-white/15 bg-white/5 px-4 py-2 text-sm font-semibold text-slate-200">
+                  View GitHub
+                </SmartLink>
+                <SmartLink href="mailto:jamesderaja@gmail.com" className="rounded-lg border border-white/15 bg-white/5 px-4 py-2 text-sm font-semibold text-slate-200">
+                  Contact
+                </SmartLink>
+              </div>
+            </section>
+          </div>
+
+          <motion.div className="order-1 lg:order-2 lg:sticky lg:top-24 lg:self-start" style={{ scale: railProgress }}>
+            <VisualJourneyCharacter stage={journeyStages[activeIndex]} progress={stageProgress} />
+          </motion.div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/visual-journey/types.ts
+++ b/src/components/visual-journey/types.ts
@@ -1,0 +1,19 @@
+export type VisualState =
+  | 'college'
+  | 'first-games'
+  | 'hyper-casual'
+  | 'publisher'
+  | 'performance'
+  | 'xr'
+  | 'current';
+
+export interface JourneyStageData {
+  id: string;
+  phase: string;
+  title: string;
+  description: string;
+  bubbles: string[];
+  metrics?: string[];
+  chips?: string[];
+  visualState: VisualState;
+}

--- a/src/lab/pages/FramePacingLabPage.tsx
+++ b/src/lab/pages/FramePacingLabPage.tsx
@@ -8,7 +8,7 @@ export default function FramePacingLabPage() {
       <Seo
         title="Frame Pacing Lab — James De Raja"
         description="Frame pacing lab focused on variance, spikes, and cadence stability beyond average FPS using profiler-backed measurements."
-        url="https://jamesderaja.com/lab/frame-pacing"
+        url="https://james.alphaden.club/lab/frame-pacing"
         keywords="frame pacing, frame variance, Unity profiler, stutter analysis"
         type="article"
         structuredData={{

--- a/src/lab/pages/FramePacingVsFPSLabPage.tsx
+++ b/src/lab/pages/FramePacingVsFPSLabPage.tsx
@@ -13,7 +13,7 @@ export default function FramePacingVsFPSLabPage() {
       <Seo
         title="Frame Pacing vs FPS Lab — James De Raja"
         description="Lab article showing why stable frame pacing can outperform higher but inconsistent FPS in XR and real-time rendering workloads."
-        url="https://jamesderaja.com/lab/frame-pacing-vs-fps"
+        url="https://james.alphaden.club/lab/frame-pacing-vs-fps"
         keywords="frame pacing vs FPS, XR performance, frame stability, Unity"
         type="article"
         structuredData={{

--- a/src/lab/pages/InstancingLabPage.tsx
+++ b/src/lab/pages/InstancingLabPage.tsx
@@ -9,7 +9,7 @@ export default function InstancingLabPage() {
       <Seo
         title="Instancing Lab — James De Raja"
         description="Instancing lab comparing draw submission overhead and CPU render-thread savings between instanced and non-instanced scenes."
-        url="https://jamesderaja.com/lab/instancing"
+        url="https://james.alphaden.club/lab/instancing"
         keywords="instancing lab, draw calls, render thread, Unity optimization"
         type="article"
         structuredData={{

--- a/src/lab/pages/MSAALabPage.tsx
+++ b/src/lab/pages/MSAALabPage.tsx
@@ -9,7 +9,7 @@ export default function MSAALabPage() {
       <Seo
         title="MSAA Scaling Lab — James De Raja"
         description="MSAA scaling lab measuring GPU bandwidth amplification and frame-time impact across anti-aliasing levels in controlled Unity scenes."
-        url="https://jamesderaja.com/lab/msaa"
+        url="https://james.alphaden.club/lab/msaa"
         keywords="MSAA scaling, Unity performance, GPU bandwidth, anti-aliasing"
         type="article"
         structuredData={{

--- a/src/lab/pages/MSAAOverdrawLabPage.tsx
+++ b/src/lab/pages/MSAAOverdrawLabPage.tsx
@@ -7,7 +7,7 @@ export default function MSAAOverdrawLabPage() {
       <Seo
         title="MSAA + Overdraw Lab — James De Raja"
         description="Landing route for the MSAA-overdraw interaction study covering compounded bandwidth and fragment pressure in Unity XR rendering."
-        url="https://jamesderaja.com/lab/msaa-overdraw"
+        url="https://james.alphaden.club/lab/msaa-overdraw"
         keywords="MSAA overdraw, Unity XR, bandwidth amplification, fragment bottleneck"
         type="article"
         structuredData={{

--- a/src/lab/pages/OverdrawLabPage.tsx
+++ b/src/lab/pages/OverdrawLabPage.tsx
@@ -9,7 +9,7 @@ export default function OverdrawLabPage() {
       <Seo
         title="Overdraw Lab — James De Raja"
         description="Controlled overdraw stress test quantifying fragment pressure, transparent pass escalation, and GPU bottleneck behavior in Unity XR."
-        url="https://jamesderaja.com/lab/overdraw"
+        url="https://james.alphaden.club/lab/overdraw"
         keywords="overdraw lab, GPU fragment pressure, Unity XR, transparent pass"
         type="article"
         structuredData={{

--- a/src/lab/pages/OverdrawStereoLabPage.tsx
+++ b/src/lab/pages/OverdrawStereoLabPage.tsx
@@ -11,7 +11,7 @@ export default function OverdrawStereoLabPage() {
       <Seo
         title="Stereo Overdraw Lab — James De Raja"
         description="Stereo overdraw lab evaluating double-eye transparency cost, fragment amplification, and GPU budget pressure in XR rendering."
-        url="https://jamesderaja.com/lab/overdraw-stereo"
+        url="https://james.alphaden.club/lab/overdraw-stereo"
         keywords="stereo overdraw, XR rendering, fragment cost, Unity performance"
         type="article"
         structuredData={{

--- a/src/lab/pages/XRFrameTimingLabPage.tsx
+++ b/src/lab/pages/XRFrameTimingLabPage.tsx
@@ -12,7 +12,7 @@ export default function XRFrameTimingLabPage() {
       <Seo
         title="XR Frame Timing Lab — James De Raja"
         description="Lab article on XR frame deadlines, compositor sync points, and practical profiling signals for reducing reprojection risk."
-        url="https://jamesderaja.com/lab/xr-frame-timing"
+        url="https://james.alphaden.club/lab/xr-frame-timing"
         keywords="XR frame timing, compositor deadlines, reprojection, Unity XR"
         type="article"
         structuredData={{

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -29,7 +29,7 @@ export default function HomePage() {
       <Seo
         title="James De Raja — Senior Real-Time Performance Engineer | Unity Rendering & XR Performance"
         description="Senior Unity and real-time performance engineer focused on XR frame budgets, rendering optimisation, CPU/GPU bottleneck isolation, and profiler-validated case studies."
-        url="https://jamesderaja.com/"
+        url="https://james.alphaden.club/"
         keywords="senior unity engineer, real-time performance engineer, Unity rendering, XR optimization, frame pacing, GPU bottleneck, CPU bottleneck isolation, mobile game optimization, Unity profiler, XR performance, James De Raja"
       />
 

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -8,7 +8,7 @@ export default function NotFoundPage() {
       <Seo
         title="Page Not Found — James De Raja"
         description="The page you're looking for doesn't exist."
-        url="https://jamesderaja.com/404"
+        url="https://james.alphaden.club/404"
       />
       <p className="font-mono text-8xl font-bold gradient-text">404</p>
       <h1 className="mt-4 text-2xl font-semibold text-white">Page not found</h1>

--- a/src/pages/VisualJourney.tsx
+++ b/src/pages/VisualJourney.tsx
@@ -1,0 +1,21 @@
+import { Seo } from '../components/Seo';
+import VisualJourneyHero from '../components/visual-journey/VisualJourneyHero';
+import VisualJourneyPage from '../components/visual-journey/VisualJourneyPage';
+
+export default function VisualJourney() {
+  return (
+    <div className="relative min-h-screen bg-void-950 text-slate-200">
+      <Seo
+        title="Visual Journey — James De Raja | Interactive Resume Through Real-Time Systems"
+        description="Scroll-driven interactive resume following James De Raja's path from Unity prototypes to XR rendering and frame-budget performance engineering."
+        url="https://james.alphaden.club/visual-journey"
+        keywords="interactive resume, Unity performance engineer, XR optimization, frame pacing, rendering optimization"
+      />
+      <div className="pointer-events-none fixed inset-0 z-0 bg-grid-overlay" aria-hidden="true" />
+      <div className="relative z-10">
+        <VisualJourneyHero />
+        <VisualJourneyPage />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Point the site and SEO metadata to the new domain `james.alphaden.club` across pages and public assets.
- Add a scroll-driven interactive "Visual Journey" resume to showcase career phases and performance work.
- Ensure internal link handling, sitemap, and robots are consistent with the new domain to preserve SEO and navigation.

### Description
- Replaced occurrences of `jamesderaja.com` with `james.alphaden.club` in `index.html`, `public/robots.txt`, `public/sitemap.xml`, multiple page `Seo` props, and the `personSchema.url` in `src/components/Seo.tsx` to update canonical/OG/meta URLs.
- Updated `SmartLink` internal host whitelist to recognize `james.alphaden.club` as an internal hostname.
- Added a new Visual Journey feature including page and route: `src/pages/VisualJourney.tsx`, route registration in `src/App.tsx`, and a footer link to `/visual-journey`.
- Implemented the visual journey UI and subcomponents under `src/components/visual-journey/` (`VisualJourneyHero`, `VisualJourneyPage`, `JourneyStage`, `VisualJourneyCharacter`, `ThoughtBubble`, `FloatingMetric`, `ScrollProgressRail`, and `types`) and wired them into the site layout.
- Appended a new sitemap entry for `/visual-journey` and adjusted sitemap dates and existing locs to the new domain.

### Testing
- Ran TypeScript type-check (`npm run type-check`) which completed successfully.
- Performed a production build (`npm run build`) which succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0d400db0083249d42f4fed8f6ca59)