### PR TITLE
Improve route-level SEO metadata and canonical handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,29 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="theme-color" content="#030308" />
-    <title>James De Raja — Real-Time Performance Engineer | Unity Rendering & Frame Stability</title>
+    <title>James De Raja — Real-time performance engineer | Unity, XR and rendering</title>
     <meta
       name="description"
-      content="Real-time performance engineer with 13+ years in Unity. Shipped mobile titles, XR/VR optimization, GPU/CPU bottleneck isolation, and frame pacing research with profiler-validated measurements."
+      content="Portfolio of James De Raja, a Unity and real-time performance engineer specializing in frame pacing, XR optimization, rendering bottlenecks, and profiler-backed performance studies."
     />
-    <link rel="canonical" href="https://jamesderaja.com/" />
+    <link rel="canonical" href="https://james.alphaden.club/" />
     <meta name="robots" content="index,follow" />
     <meta name="author" content="James De Raja" />
     <meta
       name="keywords"
       content="James De Raja, real-time performance engineer, Unity rendering, XR optimization, frame pacing, GPU bottleneck, mobile game optimization, shipped games"
     />
-    <meta property="og:title" content="James De Raja — Real-Time Performance Engineer | Unity & XR" />
+    <meta property="og:title" content="James De Raja — Real-time performance engineer | Unity, XR and rendering" />
     <meta
       property="og:description"
       content="13+ years and 100+ shipped titles. GPU/CPU bottleneck isolation, XR stereo rendering, and frame pacing research with profiler evidence."
     />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://jamesderaja.com/" />
+    <meta property="og:url" content="https://james.alphaden.club/" />
     <meta property="og:image" content="/og-image.png" />
     <meta property="og:site_name" content="James De Raja Portfolio" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="James De Raja — Real-Time Performance Engineer | Unity & XR" />
+    <meta name="twitter:title" content="James De Raja — Real-time performance engineer | Unity, XR and rendering" />
     <meta
       name="twitter:description"
       content="13+ years and 100+ shipped titles. GPU/CPU bottleneck isolation, XR stereo rendering, and frame pacing research with profiler evidence."

--- a/src/caseStudies/pages/ProfilingToolkitCaseStudyPage.tsx
+++ b/src/caseStudies/pages/ProfilingToolkitCaseStudyPage.tsx
@@ -16,9 +16,8 @@ export default function ProfilingToolkitCaseStudyPage() {
         <Seo
           title="Profiling Toolkit Case Study — James De Raja"
           description="Case study on a Unity runtime profiling overlay that shortens bottleneck triage from symptom capture to mitigation-ready evidence."
-          url="https://jamesderaja.com/case-studies/profiling-toolkit"
-          keywords="Unity profiler toolkit, runtime overlay, bottleneck triage, performance telemetry"
-          type="article"
+          canonicalPath="https://james.alphaden.club/case-studies/profiling-toolkit"
+          ogType="article"
           structuredData={{
             '@context': 'https://schema.org',
             '@type': 'Article',

--- a/src/caseStudies/pages/PublishedMobileProjectsCaseStudyPage.tsx
+++ b/src/caseStudies/pages/PublishedMobileProjectsCaseStudyPage.tsx
@@ -24,9 +24,8 @@ export default function PublishedMobileProjectsCaseStudyPage() {
       <Seo
         title="Sneaky Warrior 3D Case Study — James De Raja"
         description="Mobile performance case study covering frame budget stabilization for Sneaky Warrior 3D under heavy AI, ragdoll, and projectile load."
-        url="https://jamesderaja.com/case-studies/published-mobile-projects"
-        keywords="mobile performance, Unity optimization, frame budget, Sneaky Warrior 3D, frame pacing"
-        type="article"
+        canonicalPath="https://james.alphaden.club/case-studies/published-mobile-projects"
+        ogType="article"
         structuredData={{
           '@context': 'https://schema.org',
           '@type': 'Article',

--- a/src/caseStudies/pages/SoftMaskProCaseStudyPage.tsx
+++ b/src/caseStudies/pages/SoftMaskProCaseStudyPage.tsx
@@ -76,11 +76,10 @@ export default function SoftMaskProCaseStudyPage() {
 
       <main className="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
         <Seo
-          title="SoftMaskPro Optimization Case Study — James De Raja"
-          description="SoftMaskPro profiling and patching case study focused on UI mask draw calls, render pass overhead, and frame-time stabilization in Unity."
-          url="https://jamesderaja.com/case-studies/softmaskpro"
-          keywords="SoftMaskPro, Unity UI optimization, draw calls, frame timing, profiling"
-          type="article"
+          title="SoftMaskPro performance study — Unity UI masking and overdraw | James De Raja"
+          description="A Unity UI performance study analyzing masking cost, stacked transparency, overdraw, Canvas rebuild behavior, and GPU/CPU bottlenecks in controlled rendering tests."
+          canonicalPath="https://james.alphaden.club/case-studies/softmaskpro"
+          ogType="article"
           structuredData={{
             '@context': 'https://schema.org',
             '@type': 'Article',

--- a/src/caseStudies/pages/UpdateStrategiesCaseStudyPage.tsx
+++ b/src/caseStudies/pages/UpdateStrategiesCaseStudyPage.tsx
@@ -155,11 +155,10 @@ export default function UpdateStrategiesCaseStudyPage() {
   return (
     <div className="min-h-screen bg-void-950">
       <Seo
-        title="Update Strategies at Scale — James De Raja"
-        description="Profiler-driven comparison of 4 Unity update architectures (MonoBehaviour, Manager, ECS) across 10,000 entities. Frame time reduced from ~40 ms to ~9.4 ms."
-        url="https://jamesderaja.com/case-studies/update-strategies-scale"
-        keywords="Unity ECS, MonoBehaviour update, central manager, DOTS, performance, 10000 entities, Unity profiling"
-        type="article"
+        title="Update strategies at scale — Unity Update, manager and ECS benchmark | James De Raja"
+        description="A Unity performance benchmark comparing per-object Update, centralized manager execution, and ECS architecture under large-scale enemy and projectile simulation."
+        canonicalPath="https://james.alphaden.club/case-studies/update-strategies-scale"
+        ogType="article"
         structuredData={{
           '@context': 'https://schema.org',
           '@type': 'Article',

--- a/src/caseStudies/pages/UpdateStrategiesVariantAPage.tsx
+++ b/src/caseStudies/pages/UpdateStrategiesVariantAPage.tsx
@@ -76,9 +76,8 @@ export default function UpdateStrategiesVariantAPage() {
       <Seo
         title="Variant A — Lifecycle Control | Update Strategies at Scale"
         description="Deep dive into Scene A of the Unity update architecture study: 10,000 passive enemies with bullet lifecycle churn. Establishes the render and GC baseline."
-        url="https://jamesderaja.com/case-studies/update-strategies-scale/variant-a"
-        keywords="Unity lifecycle, MonoBehaviour baseline, Instantiate Destroy, GC alloc, Unity profiling, 10000 entities"
-        type="article"
+        canonicalPath="https://james.alphaden.club/case-studies/update-strategies-scale/variant-a"
+        ogType="article"
       />
 
       <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">

--- a/src/caseStudies/pages/UpdateStrategiesVariantBPage.tsx
+++ b/src/caseStudies/pages/UpdateStrategiesVariantBPage.tsx
@@ -74,9 +74,8 @@ export default function UpdateStrategiesVariantBPage() {
       <Seo
         title="Variant B — Per-Object Update | Update Strategies at Scale"
         description="Deep dive into Scene B: 10,000 MonoBehaviour Update calls, 8.62 ms ScriptRunBehaviourUpdate, and why per-object update does not scale in Unity."
-        url="https://jamesderaja.com/case-studies/update-strategies-scale/variant-b"
-        keywords="MonoBehaviour Update, ScriptRunBehaviourUpdate, Unity performance, 10000 entities, update dispatch overhead"
-        type="article"
+        canonicalPath="https://james.alphaden.club/case-studies/update-strategies-scale/variant-b"
+        ogType="article"
       />
 
       <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">

--- a/src/caseStudies/pages/UpdateStrategiesVariantCPage.tsx
+++ b/src/caseStudies/pages/UpdateStrategiesVariantCPage.tsx
@@ -83,9 +83,8 @@ export default function UpdateStrategiesVariantCPage() {
       <Seo
         title="Variant C — Central Manager | Update Strategies at Scale"
         description="Deep dive into Scene C: a single manager MonoBehaviour replaces 10,000 per-object Updates. Script cost drops from 8.62 ms to 4.34 ms, but Transform iteration remains the bottleneck."
-        url="https://jamesderaja.com/case-studies/update-strategies-scale/variant-c"
-        keywords="Unity central manager, MonoBehaviour optimization, Transform iteration, Unity performance, update pattern"
-        type="article"
+        canonicalPath="https://james.alphaden.club/case-studies/update-strategies-scale/variant-c"
+        ogType="article"
       />
 
       <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">

--- a/src/caseStudies/pages/UpdateStrategiesVariantDPage.tsx
+++ b/src/caseStudies/pages/UpdateStrategiesVariantDPage.tsx
@@ -107,9 +107,8 @@ export default function UpdateStrategiesVariantDPage() {
       <Seo
         title="Variant D — ECS (DOTS) | Update Strategies at Scale"
         description="Deep dive into Scene D: Unity ECS replaces MonoBehaviours entirely. Frame time drops from ~40 ms to ~9.4 ms — a 4× improvement under 10,000 enemies and maximum bullet pressure."
-        url="https://jamesderaja.com/case-studies/update-strategies-scale/variant-d"
-        keywords="Unity ECS, DOTS, entity component system, Burst compiler, chunk iteration, MonoBehaviour replacement, Unity performance"
-        type="article"
+        canonicalPath="https://james.alphaden.club/case-studies/update-strategies-scale/variant-d"
+        ogType="article"
       />
 
       <main className="mx-auto max-w-4xl px-4 py-12 sm:px-6 lg:px-8">

--- a/src/caseStudies/pages/XRStressLabCaseStudyPage.tsx
+++ b/src/caseStudies/pages/XRStressLabCaseStudyPage.tsx
@@ -60,17 +60,16 @@ export default function XRStressLabCaseStudyPage() {
       </div>
 
       <Seo
-        title="XR Stress Lab Case Study — James De Raja"
-        description="Controlled XR stress tests isolating overdraw, MSAA bandwidth, submission overhead, and frame pacing variance with profiler-backed evidence."
-        url="https://jamesderaja.com/case-studies/xr-stress-lab"
-        keywords="XR stress lab, overdraw, MSAA, instancing, frame pacing, Unity profiling"
-        type="article"
+        title="XR performance lab — Stereo rendering and overdraw analysis | James De Raja"
+        description="A Unity XR performance study measuring stereo rendering cost, overdraw amplification, GPU frame time, MSAA impact, and rendering bottlenecks under controlled stress."
+        canonicalPath="https://james.alphaden.club/case-studies/xr-stress-lab"
+        ogType="article"
         structuredData={{
           '@context': 'https://schema.org',
           '@type': 'Article',
           headline: 'XR Stress Lab Case Study',
           description:
-            'Controlled XR stress tests isolating overdraw, MSAA bandwidth, submission overhead, and frame pacing variance with profiler-backed evidence.',
+            'A Unity XR performance study measuring stereo rendering cost, overdraw amplification, GPU frame time, MSAA impact, and rendering bottlenecks under controlled stress.',
           author: { '@type': 'Person', name: 'James De Raja' },
           datePublished: '2025-01-01',
           image: '/og-image.png',

--- a/src/components/Seo.tsx
+++ b/src/components/Seo.tsx
@@ -5,28 +5,43 @@ type JsonLd = Record<string, unknown> | Array<Record<string, unknown>>;
 export type SEOProps = {
   title: string;
   description: string;
-  url: string;
-  image?: string;
-  keywords?: string;
-  type?: string;
+  canonicalPath: string;
+  ogTitle?: string;
+  ogDescription?: string;
+  ogImage?: string;
+  ogType?: string;
+  twitterTitle?: string;
+  twitterDescription?: string;
+  noindex?: boolean;
   structuredData?: JsonLd;
 };
 
 export function Seo({
   title,
   description,
-  url,
-  image = '/og-image.png',
-  keywords,
-  type = 'website',
+  canonicalPath,
+  ogTitle,
+  ogDescription,
+  ogImage = '/og-image.png',
+  ogType = 'website',
+  twitterTitle,
+  twitterDescription,
+  noindex = false,
   structuredData,
 }: SEOProps) {
+  const siteUrl = 'https://james.alphaden.club';
+  const canonicalUrl = new URL(canonicalPath, siteUrl).toString();
+  const resolvedOgTitle = ogTitle ?? title;
+  const resolvedOgDescription = ogDescription ?? description;
+  const resolvedTwitterTitle = twitterTitle ?? resolvedOgTitle;
+  const resolvedTwitterDescription = twitterDescription ?? resolvedOgDescription;
+  const resolvedImage = new URL(ogImage, siteUrl).toString();
   const personSchema = {
     '@context': 'https://schema.org',
     '@type': 'Person',
     name: 'James De Raja',
     jobTitle: 'Senior Real-Time Performance Engineer',
-    url: 'https://jamesderaja.com',
+    url: 'https://james.alphaden.club',
     email: 'jamesderaja@gmail.com',
     address: {
       '@type': 'PostalAddress',
@@ -62,20 +77,19 @@ export function Seo({
     <Helmet>
       <title>{title}</title>
       <meta name="description" content={description} />
-      {keywords && <meta name="keywords" content={keywords} />}
-      <link rel="canonical" href={url} />
-      <meta name="robots" content="index,follow" />
+      <link rel="canonical" href={canonicalUrl} />
+      <meta name="robots" content={noindex ? 'noindex,nofollow' : 'index,follow'} />
       <meta name="author" content="James De Raja" />
-      <meta property="og:title" content={title} />
-      <meta property="og:description" content={description} />
-      <meta property="og:type" content={type} />
-      <meta property="og:url" content={url} />
-      <meta property="og:image" content={image} />
+      <meta property="og:title" content={resolvedOgTitle} />
+      <meta property="og:description" content={resolvedOgDescription} />
+      <meta property="og:type" content={ogType} />
+      <meta property="og:url" content={canonicalUrl} />
+      <meta property="og:image" content={resolvedImage} />
       <meta property="og:site_name" content="James De Raja Portfolio" />
       <meta name="twitter:card" content="summary_large_image" />
-      <meta name="twitter:title" content={title} />
-      <meta name="twitter:description" content={description} />
-      <meta name="twitter:image" content={image} />
+      <meta name="twitter:title" content={resolvedTwitterTitle} />
+      <meta name="twitter:description" content={resolvedTwitterDescription} />
+      <meta name="twitter:image" content={resolvedImage} />
       {schemas.map((schema, index) => (
         <script key={index} type="application/ld+json">{JSON.stringify(schema)}</script>
       ))}

--- a/src/lab/pages/FramePacingLabPage.tsx
+++ b/src/lab/pages/FramePacingLabPage.tsx
@@ -8,9 +8,8 @@ export default function FramePacingLabPage() {
       <Seo
         title="Frame Pacing Lab — James De Raja"
         description="Frame pacing lab focused on variance, spikes, and cadence stability beyond average FPS using profiler-backed measurements."
-        url="https://jamesderaja.com/lab/frame-pacing"
-        keywords="frame pacing, frame variance, Unity profiler, stutter analysis"
-        type="article"
+        canonicalPath="https://james.alphaden.club/lab/frame-pacing"
+        ogType="article"
         structuredData={{
           '@context': 'https://schema.org',
           '@type': 'CreativeWork',

--- a/src/lab/pages/FramePacingVsFPSLabPage.tsx
+++ b/src/lab/pages/FramePacingVsFPSLabPage.tsx
@@ -13,9 +13,8 @@ export default function FramePacingVsFPSLabPage() {
       <Seo
         title="Frame Pacing vs FPS Lab — James De Raja"
         description="Lab article showing why stable frame pacing can outperform higher but inconsistent FPS in XR and real-time rendering workloads."
-        url="https://jamesderaja.com/lab/frame-pacing-vs-fps"
-        keywords="frame pacing vs FPS, XR performance, frame stability, Unity"
-        type="article"
+        canonicalPath="https://james.alphaden.club/lab/frame-pacing-vs-fps"
+        ogType="article"
         structuredData={{
           '@context': 'https://schema.org',
           '@type': 'CreativeWork',

--- a/src/lab/pages/InstancingLabPage.tsx
+++ b/src/lab/pages/InstancingLabPage.tsx
@@ -9,9 +9,8 @@ export default function InstancingLabPage() {
       <Seo
         title="Instancing Lab — James De Raja"
         description="Instancing lab comparing draw submission overhead and CPU render-thread savings between instanced and non-instanced scenes."
-        url="https://jamesderaja.com/lab/instancing"
-        keywords="instancing lab, draw calls, render thread, Unity optimization"
-        type="article"
+        canonicalPath="https://james.alphaden.club/lab/instancing"
+        ogType="article"
         structuredData={{
           '@context': 'https://schema.org',
           '@type': 'CreativeWork',

--- a/src/lab/pages/MSAALabPage.tsx
+++ b/src/lab/pages/MSAALabPage.tsx
@@ -9,9 +9,8 @@ export default function MSAALabPage() {
       <Seo
         title="MSAA Scaling Lab — James De Raja"
         description="MSAA scaling lab measuring GPU bandwidth amplification and frame-time impact across anti-aliasing levels in controlled Unity scenes."
-        url="https://jamesderaja.com/lab/msaa"
-        keywords="MSAA scaling, Unity performance, GPU bandwidth, anti-aliasing"
-        type="article"
+        canonicalPath="https://james.alphaden.club/lab/msaa"
+        ogType="article"
         structuredData={{
           '@context': 'https://schema.org',
           '@type': 'CreativeWork',

--- a/src/lab/pages/MSAAOverdrawLabPage.tsx
+++ b/src/lab/pages/MSAAOverdrawLabPage.tsx
@@ -7,9 +7,8 @@ export default function MSAAOverdrawLabPage() {
       <Seo
         title="MSAA + Overdraw Lab — James De Raja"
         description="Landing route for the MSAA-overdraw interaction study covering compounded bandwidth and fragment pressure in Unity XR rendering."
-        url="https://jamesderaja.com/lab/msaa-overdraw"
-        keywords="MSAA overdraw, Unity XR, bandwidth amplification, fragment bottleneck"
-        type="article"
+        canonicalPath="https://james.alphaden.club/lab/msaa-overdraw"
+        ogType="article"
         structuredData={{
           '@context': 'https://schema.org',
           '@type': 'CreativeWork',

--- a/src/lab/pages/OverdrawLabPage.tsx
+++ b/src/lab/pages/OverdrawLabPage.tsx
@@ -9,9 +9,8 @@ export default function OverdrawLabPage() {
       <Seo
         title="Overdraw Lab — James De Raja"
         description="Controlled overdraw stress test quantifying fragment pressure, transparent pass escalation, and GPU bottleneck behavior in Unity XR."
-        url="https://jamesderaja.com/lab/overdraw"
-        keywords="overdraw lab, GPU fragment pressure, Unity XR, transparent pass"
-        type="article"
+        canonicalPath="https://james.alphaden.club/lab/overdraw"
+        ogType="article"
         structuredData={{
           '@context': 'https://schema.org',
           '@type': 'CreativeWork',

--- a/src/lab/pages/OverdrawStereoLabPage.tsx
+++ b/src/lab/pages/OverdrawStereoLabPage.tsx
@@ -11,9 +11,8 @@ export default function OverdrawStereoLabPage() {
       <Seo
         title="Stereo Overdraw Lab — James De Raja"
         description="Stereo overdraw lab evaluating double-eye transparency cost, fragment amplification, and GPU budget pressure in XR rendering."
-        url="https://jamesderaja.com/lab/overdraw-stereo"
-        keywords="stereo overdraw, XR rendering, fragment cost, Unity performance"
-        type="article"
+        canonicalPath="https://james.alphaden.club/lab/overdraw-stereo"
+        ogType="article"
         structuredData={{
           '@context': 'https://schema.org',
           '@type': 'CreativeWork',

--- a/src/lab/pages/XRFrameTimingLabPage.tsx
+++ b/src/lab/pages/XRFrameTimingLabPage.tsx
@@ -12,9 +12,8 @@ export default function XRFrameTimingLabPage() {
       <Seo
         title="XR Frame Timing Lab — James De Raja"
         description="Lab article on XR frame deadlines, compositor sync points, and practical profiling signals for reducing reprojection risk."
-        url="https://jamesderaja.com/lab/xr-frame-timing"
-        keywords="XR frame timing, compositor deadlines, reprojection, Unity XR"
-        type="article"
+        canonicalPath="https://james.alphaden.club/lab/xr-frame-timing"
+        ogType="article"
         structuredData={{
           '@context': 'https://schema.org',
           '@type': 'CreativeWork',

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -27,10 +27,9 @@ export default function HomePage() {
   return (
     <div className="relative min-h-screen bg-void-950 text-slate-200">
       <Seo
-        title="James De Raja — Senior Real-Time Performance Engineer | Unity Rendering & XR Performance"
-        description="Senior Unity and real-time performance engineer focused on XR frame budgets, rendering optimisation, CPU/GPU bottleneck isolation, and profiler-validated case studies."
-        url="https://jamesderaja.com/"
-        keywords="senior unity engineer, real-time performance engineer, Unity rendering, XR optimization, frame pacing, GPU bottleneck, CPU bottleneck isolation, mobile game optimization, Unity profiler, XR performance, James De Raja"
+        title="James De Raja — Real-time performance engineer | Unity, XR and rendering"
+        description="Portfolio of James De Raja, a Unity and real-time performance engineer specializing in frame pacing, XR optimization, rendering bottlenecks, and profiler-backed performance studies."
+        canonicalPath="/"
       />
 
       {/* Particle background */}

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -8,7 +8,7 @@ export default function NotFoundPage() {
       <Seo
         title="Page Not Found — James De Raja"
         description="The page you're looking for doesn't exist."
-        url="https://jamesderaja.com/404"
+        canonicalPath="https://james.alphaden.club/404"
       />
       <p className="font-mono text-8xl font-bold gradient-text">404</p>
       <h1 className="mt-4 text-2xl font-semibold text-white">Page not found</h1>


### PR DESCRIPTION
### Motivation
- Standardize and improve per-route SEO so each page has a recruiter-friendly browser/social title, meta description, canonical URL, Open Graph and Twitter metadata without changing UI, routes, or visible content.
- Ensure all metadata resolves to the production domain `https://james.alphaden.club` and use a single default social preview image when no page-specific image exists.
- Provide a reusable SEO contract to make future metadata updates consistent across pages.

### Description
- Refactored the shared SEO component at `src/components/Seo.tsx` to accept `canonicalPath`, `ogTitle`, `ogDescription`, `ogImage`, `ogType`, `twitterTitle`, `twitterDescription`, and `noindex`, and to resolve canonical/OG/Twitter URLs against `https://james.alphaden.club` with sane defaults.
- Updated route pages to the new API (replacing `url`, `type`, and `keywords` wiring with `canonicalPath` and `ogType`) and applied recruiter-focused titles/descriptions for the homepage, XR stress lab, update strategies case study, and SoftMaskPro case study, while preserving existing structured data where present.
- Normalized the static fallback metadata in `index.html` to the new domain and homepage branding and kept the existing `/og-image.png` asset as the default social preview image.
- Removed route-level `keywords` output and ensured a single active `<title>`, `link rel="canonical"`, Open Graph, and Twitter preview metadata are rendered via the shared component.

### Testing
- Built the production bundle successfully with `npm run build` (Vite production build completed without errors).
- Verified programmatic replacements and metadata wiring via repository searches (`rg`) to confirm `canonicalPath` and domain normalization were applied to route files.
- Confirmed the site still builds into `dist/` with updated `index.html` containing the new canonical and social metadata.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f188691b20832498a049fa6fc8f0ad)