### PR TITLE
Deterministic neon‑lime performance‑dashboard hero, palette tweaks, and favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="alternate icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="theme-color" content="#030308" />
     <title>James De Raja — Real-time performance engineer | Unity, XR and rendering</title>
     <meta

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,8 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3" y="3" width="58" height="58" rx="14" fill="#05080A"/>
+  <rect x="3" y="3" width="58" height="58" rx="14" stroke="#9DFF00" stroke-width="2"/>
+  <path d="M10 46C18 40 22 40 30 46" stroke="#9DFF00" stroke-opacity="0.25"/>
+  <path d="M11 19C18 24 24 24 33 19" stroke="#9DFF00" stroke-opacity="0.2"/>
+  <path d="M22.5 17V40.2C22.5 45.1 19.7 47.4 15.3 47.4C13.2 47.4 11.5 46.8 10.1 45.6L12.8 40.9C13.6 41.5 14.4 41.8 15.3 41.8C16.8 41.8 17.4 41 17.4 39.2V17H22.5Z" fill="#F5F7F8"/>
+  <path d="M28 17H38.8C47.6 17 53.2 22.6 53.2 32.2C53.2 41.8 47.6 47.4 38.8 47.4H28V17ZM38.4 42C43.6 42 47.6 38.5 47.6 32.2C47.6 26 43.6 22.4 38.4 22.4H33.1V42H38.4Z" fill="#9DFF00"/>
+</svg>

--- a/src/index.css
+++ b/src/index.css
@@ -7,17 +7,17 @@
 /* ── Theme CSS variables ── */
 :root {
   /* Dark mode (default) */
-  --void-950: 3 3 8;
-  --void-900: 6 6 15;
-  --void-800: 10 10 26;
-  --void-700: 17 17 39;
-  --neon: 129 140 248;
-  --electric: 167 139 250;
+  --void-950: 5 8 10;
+  --void-900: 7 16 18;
+  --void-800: 11 17 21;
+  --void-700: 16 24 32;
+  --neon: 157 255 0;
+  --electric: 245 247 248;
   --selection-bg: 129 140 248;
   --selection-text: 255 255 255;
   --selection-link-text: 255 255 255;
 
-  color: #e2e8f0;
+  color: #f5f7f8;
   background-color: rgb(var(--void-950));
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, sans-serif;
   color-scheme: dark;
@@ -182,7 +182,7 @@ a *::selection {
 
 /* ── Animated gradient text ── */
 .gradient-text {
-  background: linear-gradient(135deg, #818cf8, #a78bfa, #818cf8);
+  background: linear-gradient(135deg, #f5f7f8, #9dff00, #f5f7f8);
   background-size: 200% 200%;
   -webkit-background-clip: text;
   background-clip: text;
@@ -257,6 +257,31 @@ a *::selection {
 }
 .animate-ticker {
   animation: ticker-scroll-up 22s linear infinite;
+}
+
+
+.hero-hud::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(157, 255, 0, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(157, 255, 0, 0.05) 1px, transparent 1px);
+  background-size: 48px 48px;
+  mask-image: radial-gradient(ellipse at top, black 45%, transparent 100%);
+  pointer-events: none;
+}
+
+.hud-label {
+  border-color: rgba(157, 255, 0, 0.45);
+  background: rgba(5, 10, 12, 0.72);
+  color: #f5f7f8;
+}
+
+.metric-panel {
+  background: rgba(5, 10, 12, 0.72);
+  border: 1px solid rgba(157, 255, 0, 0.45);
+  box-shadow: 0 0 24px rgba(157, 255, 0, 0.15);
 }
 
 /* ── Chip / tag styles ── */

--- a/src/sections/HeroBentoSection.tsx
+++ b/src/sections/HeroBentoSection.tsx
@@ -1,9 +1,8 @@
 import { motion } from 'framer-motion';
-import { ArrowRight, Mail, FileText, ExternalLink } from 'lucide-react';
+import { ArrowRight, Mail, FileText } from 'lucide-react';
 import BentoGrid from '../components/bento/BentoGrid';
 import BentoCard from '../components/bento/BentoCard';
 import SmartLink from '../components/SmartLink';
-import CountUp from '../components/CountUp';
 
 const fadeUp = {
   hidden: { opacity: 0, y: 18 },
@@ -14,101 +13,45 @@ const fadeUp = {
   }),
 };
 
-const frameBudgets = [
-  { hz: 90, ms: 11.11, pct: 67, bar: 'bg-emerald-400', text: 'text-emerald-400' },
-  { hz: 72, ms: 13.88, pct: 83, bar: 'bg-neon', text: 'text-neon' },
-  { hz: 60, ms: 16.67, pct: 100, bar: 'bg-electric', text: 'text-electric' },
-];
-
-const profilerRows = [
-  { label: 'CPU Main Thread', dot: 'bg-neon', val: '~8–12 ms' },
-  { label: 'Render Thread', dot: 'bg-electric', val: '~3–6 ms' },
-  { label: 'GPU Frame Time', dot: 'bg-amber-400', val: 'measured' },
-  { label: 'GC Alloc', dot: 'bg-red-400', val: '0 target' },
-  { label: 'Draw Calls / SetPass', dot: 'bg-emerald-400', val: 'tracked' },
-];
-
-const proofBadges = [
-  '14+ years Unity',
-  'C# / Unity 6',
-  'URP / OpenXR',
-  'XR Interaction Toolkit',
-  '1M+ installs',
-  'Voodoo · Lion Studios · Supersonic',
-];
-
-const bestFitRoles = [
-  'Senior Unity Engineer',
-  'Unity Performance Engineer',
-  'XR Performance Engineer',
-  'Rendering Engineer',
-  'Real-Time Systems Engineer',
-  'Technical Lead, Unity',
+const capabilityBadges = [
+  'Frame-time variance controlled',
+  'Predictable frame delivery',
+  'GPU bottlenecks isolated',
+  'Deterministic frame budget control',
 ];
 
 export default function HeroBentoSection() {
   return (
-    <section id="hero" className="relative mx-auto max-w-screen-2xl px-4 py-12 sm:px-6 lg:px-8">
-      {/* Ambient glows */}
+    <section id="hero" className="hero-hud relative mx-auto max-w-screen-2xl px-4 py-12 sm:px-6 lg:px-8">
       <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
-        <div className="absolute -left-32 top-0 h-[500px] w-[500px] rounded-full bg-neon/5 blur-[130px]" />
-        <div className="absolute -right-32 bottom-0 h-[400px] w-[400px] rounded-full bg-electric/4 blur-[120px]" />
+        <div className="absolute -left-24 top-0 h-[520px] w-[520px] rounded-full bg-neon/10 blur-[140px]" />
+        <div className="absolute right-0 top-1/3 h-[420px] w-[420px] rounded-full bg-neon/8 blur-[140px]" />
       </div>
 
-      {/* ── Row 1: Main hero (8 cols) + side stack (4 cols) ── */}
       <BentoGrid>
-        {/* Main hero card */}
-        <motion.div
-          className="lg:col-span-8 md:col-span-6"
-          custom={0}
-          variants={fadeUp}
-          initial="hidden"
-          animate="visible"
-        >
+        <motion.div className="lg:col-span-8 md:col-span-6" custom={0} variants={fadeUp} initial="hidden" animate="visible">
           <BentoCard variant="featured" padding="lg" elevated className="h-full flex flex-col justify-between gap-7">
             <div className="space-y-5">
-              {/* Top row: availability badge */}
               <div className="flex items-start justify-between gap-4">
-                <span className="inline-flex items-center gap-2 rounded-full border border-emerald-500/25 bg-emerald-500/[0.06] px-3 py-1 text-xs font-medium text-emerald-400">
-                  <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 animate-pulse" />
-                  Open to senior roles — Unity Rendering / XR Performance
+                <span className="hud-label inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em]">
+                  Deterministic
                 </span>
               </div>
 
-              {/* Identity + title */}
-              <div className="flex items-start gap-4 sm:gap-6">
-                <div className="relative flex-shrink-0">
-                  <div className="absolute -inset-2 rounded-2xl bg-neon/10 blur-lg" aria-hidden="true" />
-                  <img
-                    src="/images/james.jpg"
-                    alt="James De Raja"
-                    className="relative h-24 w-24 sm:h-28 sm:w-28 lg:h-[140px] lg:w-[140px] rounded-2xl object-cover ring-1 ring-neon/25 shadow-[0_0_20px_rgba(129,140,248,0.2)]"
-                  />
-                </div>
-                <div>
-                  <h1 className="text-4xl font-bold tracking-tight text-white sm:text-5xl lg:text-6xl">
-                    James{' '}
-                    <span className="gradient-text">De Raja</span>
-                  </h1>
-                  <p className="mt-3 text-xl font-semibold text-white/90 sm:text-2xl">
-                    Senior Real-Time Performance Engineer
-                  </p>
-                  <p className="mt-1.5 font-mono text-sm text-neon/80">
-                    Unity Rendering&nbsp;&bull;&nbsp;XR Frame Budgets&nbsp;&bull;&nbsp;CPU/GPU Bottleneck Isolation
-                  </p>
-                </div>
+              <div>
+                <h1 className="text-4xl font-black uppercase tracking-[0.03em] text-white sm:text-5xl lg:text-6xl">
+                  Performance Engineering
+                </h1>
+                <p className="mt-3 text-xl font-semibold text-neon sm:text-2xl">
+                  James De Raja — Senior Real-Time Performance Engineer
+                </p>
+                <p className="mt-2 max-w-2xl text-base leading-relaxed text-slate-300">
+                  Real-time systems built for predictable frame delivery under load, with profiler evidence from XR and shipped production pipelines.
+                </p>
               </div>
 
-              {/* Value prop */}
-              <p className="max-w-xl text-base text-slate-300 leading-relaxed">
-                I build profiler-validated real-time systems where frame stability, rendering cost, and
-                reproducible performance evidence matter. Every claim on this site is backed by a profiler
-                screenshot, a benchmark harness, or a shipped product.
-              </p>
-
-              {/* Proof badges */}
               <div className="flex flex-wrap gap-1.5">
-                {proofBadges.map((badge) => (
+                {capabilityBadges.map((badge) => (
                   <span key={badge} className="chip-glow rounded-full px-2.5 py-1 font-mono text-xs">
                     {badge}
                   </span>
@@ -116,12 +59,8 @@ export default function HeroBentoSection() {
               </div>
             </div>
 
-            {/* CTAs */}
             <div className="flex flex-wrap gap-3">
-              <a
-                href="#case-studies"
-                className="btn-primary group inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-medium"
-              >
+              <a href="#case-studies" className="btn-primary group inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-medium">
                 View Case Studies
                 <ArrowRight size={14} className="transition group-hover:translate-x-1" />
               </a>
@@ -132,10 +71,7 @@ export default function HeroBentoSection() {
                 <FileText size={14} />
                 View Resume
               </SmartLink>
-              <a
-                href="#contact"
-                className="btn-secondary inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-medium"
-              >
+              <a href="#contact" className="btn-secondary inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-medium">
                 <Mail size={14} />
                 Contact
               </a>
@@ -143,226 +79,33 @@ export default function HeroBentoSection() {
           </BentoCard>
         </motion.div>
 
-        {/* Side stack: Frame Budget + Profiler */}
         <div className="lg:col-span-4 md:col-span-6 flex flex-col gap-4">
-          {/* Frame Budget card */}
           <motion.div custom={1} variants={fadeUp} initial="hidden" animate="visible">
-            <BentoCard variant="metric" padding="md" elevated className="h-full">
-              <div className="flex items-center justify-between mb-5">
-                <p className="font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500">
-                  Frame Budget
-                </p>
-                <span className="rounded border border-neon/15 bg-neon/[0.06] font-mono text-[10px] px-1.5 py-0.5 text-neon/70">
-                  XR targets
-                </span>
+            <BentoCard variant="metric" padding="md" elevated className="metric-panel h-full">
+              <div className="mb-5 flex items-center justify-between">
+                <p className="font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-400">Primary metric</p>
+                <span className="rounded border border-neon/40 bg-neon/[0.08] px-1.5 py-0.5 font-mono text-[10px] text-neon">GPU pipeline</span>
               </div>
-              <div className="space-y-4">
-                {frameBudgets.map((b, i) => (
-                  <div key={b.hz}>
-                    <div className="flex items-end justify-between mb-1.5">
-                      <span className={`font-mono text-xs font-semibold ${b.text}`}>{b.hz} Hz</span>
-                      <CountUp
-                        to={b.ms}
-                        decimals={2}
-                        suffix=" ms"
-                        duration={1.0}
-                        className="font-mono text-base font-bold text-white"
-                      />
-                    </div>
-                    <div className="h-2 rounded-full bg-white/[0.06]">
-                      <motion.div
-                        className={`h-full rounded-full ${b.bar} opacity-75`}
-                        initial={{ width: 0 }}
-                        whileInView={{ width: `${b.pct}%` }}
-                        viewport={{ once: true }}
-                        transition={{ duration: 1.0, delay: 0.2 + i * 0.12, ease: [0.22, 1, 0.36, 1] }}
-                      />
-                    </div>
-                  </div>
-                ))}
+              <p className="text-sm text-slate-300">Draw calls</p>
+              <p className="mt-2 font-mono text-4xl font-black text-white sm:text-5xl">
+                1250 <span className="text-slate-500">→</span> <span className="text-neon text-glow-cyan">412</span>
+              </p>
+              <p className="mt-3 font-mono text-xl font-bold text-neon">-67% GPU overhead</p>
+              <div className="mt-5 h-2 rounded-full bg-white/[0.06]">
+                <motion.div
+                  className="h-full rounded-full bg-neon"
+                  initial={{ width: 0 }}
+                  whileInView={{ width: '67%' }}
+                  viewport={{ once: true }}
+                  transition={{ duration: 1.0, delay: 0.2, ease: [0.22, 1, 0.36, 1] }}
+                />
               </div>
-              <p className="mt-4 text-[11px] text-slate-500 leading-relaxed">
-                Work measured against real frame budgets. Stable pacing over peak FPS.
+              <p className="mt-4 text-xs leading-relaxed text-slate-400">
+                Bottleneck isolated using frame debugger + GPU profiler, then validated against frame-time budget stability.
               </p>
             </BentoCard>
           </motion.div>
-
-          {/* Profiler Evidence card */}
-          <motion.div custom={2} variants={fadeUp} initial="hidden" animate="visible">
-            <BentoCard variant="metric" padding="md" elevated className="h-full">
-              <div className="flex items-center justify-between mb-4">
-                <p className="font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500">
-                  Profiler Metrics
-                </p>
-                <span className="rounded border border-white/[0.06] bg-white/[0.02] font-mono text-[10px] px-1.5 py-0.5 text-slate-600">
-                  per-frame
-                </span>
-              </div>
-              <div className="space-y-3">
-                {profilerRows.map((row) => (
-                  <div key={row.label} className="flex items-center justify-between gap-2">
-                    <div className="flex items-center gap-2.5">
-                      <span className={`h-1.5 w-1.5 flex-shrink-0 rounded-full ${row.dot}`} />
-                      <span className="text-xs text-slate-300">{row.label}</span>
-                    </div>
-                    <span className="font-mono text-[11px] text-slate-500 flex-shrink-0">{row.val}</span>
-                  </div>
-                ))}
-              </div>
-              <div className="mt-4 border-t border-white/[0.05] pt-3">
-                <p className="text-[11px] text-slate-500 leading-relaxed">
-                  Profiler-first diagnosis before optimisation. Every bottleneck proved before the fix.
-                </p>
-              </div>
-            </BentoCard>
-          </motion.div>
         </div>
-
-        {/* ── Row 2: Four bottom cards ── */}
-
-        {/* Published Results */}
-        <motion.div
-          className="lg:col-span-3 md:col-span-3"
-          custom={3}
-          variants={fadeUp}
-          initial="hidden"
-          animate="visible"
-        >
-          <a href="#experience" className="block h-full group">
-            <BentoCard variant="default" padding="md" elevated glow="green" className="h-full flex flex-col justify-between transition-all group-hover:border-emerald-500/30">
-              <div>
-                <p className="font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500 mb-4">
-                  Published Results
-                </p>
-                <div className="space-y-3">
-                  <div>
-                    <p className="font-mono text-3xl font-bold text-emerald-400">
-                      ~<CountUp to={1} suffix="M" duration={1.6} />
-                    </p>
-                    <p className="text-xs text-slate-400 mt-0.5">game installs</p>
-                  </div>
-                  <div>
-                    <p className="font-mono text-xl font-bold text-white">
-                      <CountUp to={100} suffix="+" duration={1.4} />
-                    </p>
-                    <p className="text-xs text-slate-400 mt-0.5">publisher-tested prototypes</p>
-                  </div>
-                  <div className="flex flex-wrap gap-1.5">
-                    {['Voodoo', 'Lion Studios', 'Supersonic'].map((p) => (
-                      <span
-                        key={p}
-                        className="rounded-md border border-white/10 bg-white/[0.04] px-2 py-0.5 font-mono text-[11px] text-slate-400"
-                      >
-                        {p}
-                      </span>
-                    ))}
-                  </div>
-                </div>
-              </div>
-              <div className="mt-4 pt-3 border-t border-white/[0.05] flex items-center justify-between">
-                <p className="text-[11px] text-slate-500">CPI (cost per install) and D1 retention across rapid iteration</p>
-                <ExternalLink size={10} className="text-slate-600 group-hover:text-emerald-400 transition-colors" />
-              </div>
-            </BentoCard>
-          </a>
-        </motion.div>
-
-        {/* Best Fit Roles */}
-        <motion.div
-          className="lg:col-span-3 md:col-span-3"
-          custom={4}
-          variants={fadeUp}
-          initial="hidden"
-          animate="visible"
-        >
-          <BentoCard variant="dim" padding="md" elevated className="h-full">
-            <p className="font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500 mb-4">
-              Best Fit Roles
-            </p>
-            <ul className="space-y-2.5">
-              {bestFitRoles.map((role) => (
-                <li key={role} className="flex items-start gap-2">
-                  <span className="mt-1.5 h-1 w-1 flex-shrink-0 rounded-full bg-neon/40" />
-                  <span className="text-xs text-slate-300">{role}</span>
-                </li>
-              ))}
-            </ul>
-          </BentoCard>
-        </motion.div>
-
-        {/* Engineering posture */}
-        <motion.div
-          className="lg:col-span-3 md:col-span-3"
-          custom={5}
-          variants={fadeUp}
-          initial="hidden"
-          animate="visible"
-        >
-          <a href="#evidence" className="block h-full group">
-            <BentoCard variant="dim" padding="md" elevated className="h-full flex flex-col justify-between transition-all group-hover:border-electric/20">
-              <div>
-                <p className="font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500 mb-4">
-                  Engineering Posture
-                </p>
-                <p className="text-sm text-slate-300 leading-relaxed">
-                  Not just gameplay implementation — performance diagnosis, measurable optimisation,
-                  and engineering evidence that ships.
-                </p>
-                <div className="mt-4 flex flex-wrap gap-1.5">
-                  {['Profiler-validated', 'Frame budget aware', 'Deterministic benchmarks', 'Baseline vs stress'].map((tag) => (
-                    <span
-                      key={tag}
-                      className="inline-block rounded border border-electric/15 bg-electric/[0.05] px-2 py-0.5 font-mono text-[11px] text-electric/80"
-                    >
-                      {tag}
-                    </span>
-                  ))}
-                </div>
-              </div>
-              <div className="mt-4 pt-3 border-t border-white/[0.05] flex items-center justify-between">
-                <span className="text-xs text-slate-500 group-hover:text-neon transition-colors">View evidence</span>
-                <ExternalLink size={10} className="text-slate-600 group-hover:text-neon transition-colors" />
-              </div>
-            </BentoCard>
-          </a>
-        </motion.div>
-
-        {/* Explore the Portfolio — site nav card */}
-        <motion.div
-          className="lg:col-span-3 md:col-span-3"
-          custom={6}
-          variants={fadeUp}
-          initial="hidden"
-          animate="visible"
-        >
-          <BentoCard variant="metric" padding="md" elevated className="h-full flex flex-col">
-            <p className="font-mono text-[10px] font-semibold uppercase tracking-widest text-slate-500 mb-4">
-              Explore the Portfolio
-            </p>
-            <ul className="space-y-1.5 flex-1">
-              {[
-                { label: 'Case Studies', href: '#case-studies', accent: 'text-neon' },
-                { label: 'Profiler Evidence', href: '#evidence', accent: 'text-amber-400' },
-                { label: 'Tech Focus', href: '#tech-focus', accent: 'text-electric' },
-                { label: 'Experience', href: '#experience', accent: 'text-neon' },
-                { label: 'Skills', href: '#skills', accent: 'text-emerald-400' },
-                { label: 'Contact', href: '#contact', accent: 'text-slate-400' },
-              ].map((item) => (
-                <li key={item.label}>
-                  <a
-                    href={item.href}
-                    className={`group flex items-center justify-between rounded-lg px-3 py-2 hover:bg-white/[0.04] transition-colors`}
-                  >
-                    <span className={`text-xs font-medium text-slate-300 group-hover:${item.accent} transition-colors`}>
-                      {item.label}
-                    </span>
-                    <ArrowRight size={11} className={`text-slate-600 group-hover:${item.accent} group-hover:translate-x-0.5 transition-all`} />
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </BentoCard>
-        </motion.div>
       </BentoGrid>
     </section>
   );


### PR DESCRIPTION
### Motivation
- Move the site's visual identity from a blue-violet accent to a serious, near‑black + neon‑lime dashboard look that reads as senior, technical, and systems‑level. 
- Emphasise deterministic, evidence‑driven messaging in the hero by using uppercase tracking label and outcome‑focused copy to communicate profiler‑backed performance work.
- Surface one dominant metric panel (rather than many competing widgets) to highlight a clear optimisation story (e.g. draw calls and GPU overhead). 

### Description
- Reworked the hero into a deterministic performance‑engineering HUD in `src/sections/HeroBentoSection.tsx`, adding the small tracking label `DETERMINISTIC`, main heading `PERFORMANCE ENGINEERING`, capability chips, and a single prominent metric panel showing `1250 → 412` draw calls and `-67% GPU overhead`.
- Shifted dark theme variables and accent colors in `src/index.css` to charcoal + neon‑lime (`--neon: 157 255 0`) and adjusted typography/gradient treatments and HUD/grid classes (`.hero-hud`, `.hud-label`, `.metric-panel`) to produce glassmorphism, grid overlays, and subtle neon glow.
- Added a rounded‑square SVG favicon `public/favicon.svg` (dark base, thin neon border, white `J`, neon `D`) and updated `index.html` to prefer the SVG favicon with an `.ico` fallback.

### Testing
- Built the production bundle with `npm run build` and the Vite build completed successfully (assets emitted; only non‑blocking chunk size warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38f243b948324969fa7fb218453cf)