### PR TITLE
Use favicon as navbar mark and switch primary accent to #A7FF00

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -53,8 +53,8 @@ export default function Navbar() {
       >
         {/* Logo */}
         <Link to="/" className="group flex items-center gap-2">
-          <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-neon/20 bg-neon/5">
-            <span className="font-mono text-sm font-bold text-neon">JD</span>
+          <div className="flex h-8 w-8 items-center justify-center overflow-hidden rounded-lg border border-neon/20 bg-neon/5">
+            <img src="/favicon.ico" alt="JD favicon logo" className="h-5 w-5 object-contain" />
           </div>
           <span className="text-sm font-semibold tracking-tight text-white/90 transition group-hover:text-neon">
             James De Raja

--- a/src/index.css
+++ b/src/index.css
@@ -11,9 +11,9 @@
   --void-900: 6 6 15;
   --void-800: 10 10 26;
   --void-700: 17 17 39;
-  --neon: 129 140 248;
-  --electric: 167 139 250;
-  --selection-bg: 129 140 248;
+  --neon: 167 255 0;
+  --electric: 122 199 0;
+  --selection-bg: 167 255 0;
   --selection-text: 255 255 255;
   --selection-link-text: 255 255 255;
 
@@ -29,9 +29,9 @@
   --void-900: 241 240 253;   /* #f1f0fd — slightly deeper for section contrast */
   --void-800: 255 255 255;   /* pure white card surfaces */
   --void-700: 220 219 240;   /* #dcdbe0 — subtle border/divider */
-  --neon: 99 102 241;
-  --electric: 109 40 217;
-  --selection-bg: 99 102 241;
+  --neon: 167 255 0;
+  --electric: 122 199 0;
+  --selection-bg: 167 255 0;
   --selection-text: 15 23 42;
   --selection-link-text: 15 23 42;
 


### PR DESCRIPTION
### Motivation
- Replace the top-left navbar mark with the site favicon so the brand icon matches the site's favicon file.
- Change the primary accent from the existing purple to the requested `#A7FF00` green across the theme variables for consistent UI accenting.

### Description
- Replaced the `JD` text badge with an image element that loads `/favicon.ico` inside the same rounded container in `src/components/Navbar.tsx`.
- Updated theme accent CSS variables in `src/index.css` for both dark (`:root`) and light (`.light`) roots by setting `--neon` to `167 255 0` (RGB for `#A7FF00`), `--electric` to `122 199 0`, and `--selection-bg` to `167 255 0`.
- Preserved existing container styling and left unrelated hardcoded gradients (e.g. `.gradient-text`) unchanged per the requested scope.

### Testing
- Ran `npm run build` and the production build completed successfully with no build errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f391e8dce08324a581910cd3280a1d)