### PR TITLE
Refine navbar logo treatment

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -53,7 +53,7 @@ export default function Navbar() {
       >
         {/* Logo */}
         <Link to="/" className="group flex items-center gap-2">
-          <div className="h-8 w-8 overflow-hidden rounded-lg border border-neon/35 bg-neon/5 ring-1 ring-neon/15 ring-offset-1 ring-offset-void-950">
+          <div className="h-8 w-8 overflow-hidden rounded-lg border border-neon/25 bg-neon/5">
             <img src="/favicon.ico" alt="JD favicon logo" className="h-full w-full object-cover" />
           </div>
           <span className="text-sm font-semibold tracking-tight text-white/90 transition group-hover:text-neon">

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -53,8 +53,8 @@ export default function Navbar() {
       >
         {/* Logo */}
         <Link to="/" className="group flex items-center gap-2">
-          <div className="flex h-8 w-8 items-center justify-center overflow-hidden rounded-lg border border-neon/20 bg-neon/5">
-            <img src="/favicon.ico" alt="JD favicon logo" className="h-5 w-5 object-contain" />
+          <div className="h-8 w-8 overflow-hidden rounded-lg border border-neon/35 bg-neon/5 ring-1 ring-neon/15 ring-offset-1 ring-offset-void-950">
+            <img src="/favicon.ico" alt="JD favicon logo" className="h-full w-full object-cover" />
           </div>
           <span className="text-sm font-semibold tracking-tight text-white/90 transition group-hover:text-neon">
             James De Raja

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -53,7 +53,7 @@ export default function Navbar() {
       >
         {/* Logo */}
         <Link to="/" className="group flex items-center gap-2">
-          <div className="h-8 w-8 overflow-hidden rounded-lg border border-neon/25 bg-neon/5">
+          <div className="h-8 w-8 overflow-hidden rounded-lg bg-neon/5">
             <img src="/favicon.ico" alt="JD favicon logo" className="h-full w-full object-cover" />
           </div>
           <span className="text-sm font-semibold tracking-tight text-white/90 transition group-hover:text-neon">


### PR DESCRIPTION
### Motivation
- Make the navbar favicon fill its frame (remove the inset/padded look) and add a subtle extra border so the icon reads as a filled image with a double-border treatment.  
- Avoid introducing extra page padding or layout shifts in the top-right navbar area while changing the logo appearance.

### Description
- Updated the logo container in `src/components/Navbar.tsx` to remove the inner centering/padding and let the image fill the container by changing the image classes from `h-5 w-5 object-contain` to `h-full w-full object-cover`.  
- Adjusted the container classes to keep the rounded frame and border but add a subtle neon ring and slightly stronger border via `ring-1 ring-neon/15 ring-offset-1 ring-offset-void-950` and `border-neon/35`.  
- No other layout or padding changes were made elsewhere so the navbar spacing remains unchanged.

### Testing
- Ran `npm run build` which completed successfully.  
- Ran `npm run lint` which failed due to an existing unrelated lint error (`cardVariants` unused in `src/caseStudies/pages/SoftMaskProCaseStudyPage.tsx`).  
- Attempted to install browsers with `npx playwright install chromium` for a visual check, but the download was blocked by the environment (HTTP 403), so no browser-based screenshot test could be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc1366f7488324ae163426f6b9d6a2)